### PR TITLE
Normalize README bullet formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,13 +208,13 @@ Job config:
 
 Common parameters across most benchmarks:
 
-* `Cols`           : 7
-* `RowsPerCol`     : 24 or 2048 (small vs large tables)
-* `KeySize`        : 16 bytes
-* `ValueSize`      : 64 or 256 bytes
-* `Ops`            : 10,000 logical operations per benchmark
-* `ChildPoolSize`  : 16
-* `RefsPerBatch`   : 1, 4 or 16 (for ref-related tests)
+- `Cols`           : 7
+- `RowsPerCol`     : 24 or 2048 (small vs large tables)
+- `KeySize`        : 16 bytes
+- `ValueSize`      : 64 or 256 bytes
+- `Ops`            : 10,000 logical operations per benchmark
+- `ChildPoolSize`  : 16
+- `RefsPerBatch`   : 1, 4 or 16 (for ref-related tests)
 
 ---
 
@@ -224,31 +224,31 @@ The suite is organized into high-level categories:
 
 1. **Copy**
 
-   * `Copy_A_to_B_Column0_AllRows`
-   * `Copy_InPlace_TableA_Col0_to_Col1_AllRows`
-   * Measures raw column copy throughput (inter-table and in-place).
+   - `Copy_A_to_B_Column0_AllRows`
+   - `Copy_InPlace_TableA_Col0_to_Col1_AllRows`
+   - Measures raw column copy throughput (inter-table and in-place).
 
 2. **Fill**
 
-   * `Fill_Column0_TableA`
-   * `Fill_Column0_TableB`
-   * `Fill_Typed_Small16`
-   * `Fill_Typed_Exact`
-   * `Fill_Raw_Writer`
-   * Measures different fill strategies (generic vs strongly-typed vs raw writer).
+   - `Fill_Column0_TableA`
+   - `Fill_Column0_TableB`
+   - `Fill_Typed_Small16`
+   - `Fill_Typed_Exact`
+   - `Fill_Raw_Writer`
+   - Measures different fill strategies (generic vs strongly-typed vs raw writer).
 
 4. **Refs**
 
-   * `EnsureRefVec_*`
-   * `LinkRef_*`
-   * `EnumerateRefs_CountSum`
-   * Focused on **reference vectors**, link operations and bulk linking from pools.
+   - `EnsureRefVec_*`
+   - `LinkRef_*`
+   - `EnumerateRefs_CountSum`
+   - Focused on **reference vectors**, link operations and bulk linking from pools.
 
 5. **Register**
 
-   * `RegisterTable_Lazy_NoPersist`
-   * `RegisterTable_Eager_DisposeAndDelete`
-   * Exercises table registration / lifecycle paths, with and without persistence.
+   - `RegisterTable_Lazy_NoPersist`
+   - `RegisterTable_Eager_DisposeAndDelete`
+   - Exercises table registration / lifecycle paths, with and without persistence.
 
 ---
 
@@ -265,9 +265,9 @@ Representative results (KeySize=16, ValueSize=64):
 
 Key takeaways:
 
-* For **small tables** (24 rows) the copy kernels run around **100 ns** per op.
-* For **large tables** (2048 rows) we hit around **35 GB/s write** and **~70 GB/s aggregate read+write**.
-* In-place copies (`Col0 → Col1` in the same table) are within a few percent of inter-table copies, which is good: the in-place path does not introduce hidden overhead.
+- For **small tables** (24 rows) the copy kernels run around **100 ns** per op.
+- For **large tables** (2048 rows) we hit around **35 GB/s write** and **~70 GB/s aggregate read+write**.
+- In-place copies (`Col0 → Col1` in the same table) are within a few percent of inter-table copies, which is good: the in-place path does not introduce hidden overhead.
 
 ---
 
@@ -285,14 +285,14 @@ Representative results for `RowsPerCol=24`, `KeySize=16`:
 
 For `ValueSize=256` the patterns are similar:
 
-* `Fill_Typed_Small16` stays around **~200 ns**, outperforming the generic column-fill.
-* `Fill_Typed_Exact` is a bit slower for large values but still competitive vs the baseline column fill.
-* Raw writer sits close to the column fill baseline (it’s more of a “control” path here).
+- `Fill_Typed_Small16` stays around **~200 ns**, outperforming the generic column-fill.
+- `Fill_Typed_Exact` is a bit slower for large values but still competitive vs the baseline column fill.
+- Raw writer sits close to the column fill baseline (it’s more of a “control” path here).
 
 High-level conclusions:
 
-* **Strongly-typed fills (`Fill_Typed_*`) are consistently the fastest way** to push data into the engine, especially for smaller value sizes.
-* The generic column fill (`Fill_Column0_TableA/B`) is competitive, but you pay around **2×** versus the specialized typed path on small structs.
+- **Strongly-typed fills (`Fill_Typed_*`) are consistently the fastest way** to push data into the engine, especially for smaller value sizes.
+- The generic column fill (`Fill_Column0_TableA/B`) is competitive, but you pay around **2×** versus the specialized typed path on small structs.
 
 ---
 
@@ -311,13 +311,13 @@ Representative small-table numbers (`RowsPerCol=24`, `ValueSize=64`):
 
 On large tables (`RowsPerCol=2048`):
 
-* Ensure+link runs around **~360–550 µs**, depending on `ValueSize` and batch params.
-* Bulk linking alone (`LinkRef_Bulk_PerRow`) stays noticeably faster, roughly **0.7–0.8×** of the ensure+link combo.
+- Ensure+link runs around **~360–550 µs**, depending on `ValueSize` and batch params.
+- Bulk linking alone (`LinkRef_Bulk_PerRow`) stays noticeably faster, roughly **0.7–0.8×** of the ensure+link combo.
 
 Design-wise:
 
-* Ensuring the ref vector has a **one-time cost** (cold path) that is acceptable given its rare usage.
-* The **idempotent** path is close in cost to pure linking, which means we can call `EnsureRefVec` defensively without paying a big penalty when it is already initialized.
+- Ensuring the ref vector has a **one-time cost** (cold path) that is acceptable given its rare usage.
+- The **idempotent** path is close in cost to pure linking, which means we can call `EnsureRefVec` defensively without paying a big penalty when it is already initialized.
 
 ---
 
@@ -327,30 +327,30 @@ The `Register` benchmarks focus on **table lifecycle**:
 
 * `RegisterTable_Lazy_NoPersist`
 
-  * Around **1.9–2.0 µs**.
-  * Allocations ≈ **4.7–4.8 KB**.
-  * This is the fast path for ephemeral tables.
+  - Around **1.9–2.0 µs**.
+  - Allocations ≈ **4.7–4.8 KB**.
+  - This is the fast path for ephemeral tables.
 
 * `RegisterTable_Eager_DisposeAndDelete`
 
-  * Around **2.2 ms** and above.
-  * Allocations ≈ **11 KB** and visible `Gen0` activity.
-  * This path simulates a heavier “register + persist + dispose” lifecycle and is not expected to run frequently in hot loops.
+  - Around **2.2 ms** and above.
+  - Allocations ≈ **11 KB** and visible `Gen0` activity.
+  - This path simulates a heavier “register + persist + dispose” lifecycle and is not expected to run frequently in hot loops.
 
 In other words:
 
-* **Lazy registration** is cheap enough to use at runtime for dynamic metadata.
-* **Eager + persistent** registration is more expensive by design, and should be used for long-lived / persisted tables (startup, migrations, etc.).
+- **Lazy registration** is cheap enough to use at runtime for dynamic metadata.
+- **Eager + persistent** registration is more expensive by design, and should be used for long-lived / persisted tables (startup, migrations, etc.).
 
 ---
 
 ### Summary
 
-* Column copies achieve **tens of GB/s** of effective throughput with both inter-table and in-place paths.
-* Typed fill paths (`Fill_Typed_*`) are the **preferred API for hot paths**, halving the cost versus generic column fills in typical configurations.
-* Integrity and enumeration benchmarks give us a baseline for **correctness checks** and highlight where allocations occur.
-* Ref-vector initialization and linking are within a small constant factor of raw linking, so the API can stay **ergonomic and defensive** without wrecking performance.
-* Table registration is split into **fast, lazy registration** and **heavier eager/persistent registration**, which matches the expected usage patterns.
+- Column copies achieve **tens of GB/s** of effective throughput with both inter-table and in-place paths.
+- Typed fill paths (`Fill_Typed_*`) are the **preferred API for hot paths**, halving the cost versus generic column fills in typical configurations.
+- Integrity and enumeration benchmarks give us a baseline for **correctness checks** and highlight where allocations occur.
+- Ref-vector initialization and linking are within a small constant factor of raw linking, so the API can stay **ergonomic and defensive** without wrecking performance.
+- Table registration is split into **fast, lazy registration** and **heavier eager/persistent registration**, which matches the expected usage patterns.
 
 These numbers are my current “performance budget”. Any future changes to `MetaDBManager` should be validated against this suite to avoid silent regressions.
 


### PR DESCRIPTION
## Summary
- switch README bullet points to consistent hyphen markers across benchmark notes
- adjust nested lists and key takeaways to maintain uniform formatting

## Testing
- not run (documentation changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b30adda98832e9f25d01a856f0857)