### PR TITLE
Publish the current Extend0 NuGet package set

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -128,15 +128,23 @@ jobs:
               with zipfile.ZipFile(package) as archive:
                   nuspec = next(name for name in archive.namelist() if name.endswith(".nuspec"))
                   document = ET.fromstring(archive.read(nuspec))
-                  namespace = {"n": "http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"}
-                  metadata = document.find("n:metadata", namespace)
-                  if metadata is None:
-                      metadata = document.find("metadata")
-                  package_id = metadata.findtext("n:id", namespaces=namespace) or metadata.findtext("id")
-                  package_version = (
-                      metadata.findtext("n:version", namespaces=namespace)
-                      or metadata.findtext("version")
+                  local_name = lambda element: element.tag.rsplit("}", 1)[-1]
+                  metadata = next(
+                      (element for element in document if local_name(element) == "metadata"),
+                      None,
                   )
+                  if metadata is None:
+                      raise SystemExit(f"{package.name} has no nuspec metadata element")
+
+                  def metadata_text(name):
+                      element = next(
+                          (child for child in metadata if local_name(child) == name),
+                          None,
+                      )
+                      return element.text if element is not None else None
+
+                  package_id = metadata_text("id")
+                  package_version = metadata_text("version")
                   if package_version != version:
                       raise SystemExit(
                           f"{package.name} contains version {package_version}, expected {version}"

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,0 +1,169 @@
+name: NuGet packages
+
+on:
+  pull_request:
+    paths:
+      - "Extend0/Extend0.csproj"
+      - "Extend0.Cli/Extend0.Cli.csproj"
+      - "Extend0.MetadataEntry.Generator/Extend0.MetadataEntry.Generator.csproj"
+      - "Extend0.BlittableAdapter.Generator/Extend0.BlittableAdapter.Generator.csproj"
+      - "global.json"
+      - ".github/workflows/nuget.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Extend0/Extend0.csproj"
+      - "Extend0.Cli/Extend0.Cli.csproj"
+      - "Extend0.MetadataEntry.Generator/Extend0.MetadataEntry.Generator.csproj"
+      - "Extend0.BlittableAdapter.Generator/Extend0.BlittableAdapter.Generator.csproj"
+      - "global.json"
+      - ".github/workflows/nuget.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nuget-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-15]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-dotnet@v5.4.0
+        with:
+          global-json-file: global.json
+      - name: Show SDK
+        run: dotnet --info
+      - name: Restore tests
+        run: dotnet restore Extend0.Tests/Extend0.Tests.csproj
+      - name: Run tests
+        run: dotnet test Extend0.Tests/Extend0.Tests.csproj -c Release --no-restore
+      - name: Build CLI
+        run: dotnet build Extend0.Cli/Extend0.Cli.csproj -c Release
+
+  pack:
+    needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-dotnet@v5.4.0
+        with:
+          global-json-file: global.json
+      - name: Verify coherent package version
+        id: version
+        shell: bash
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import xml.etree.ElementTree as ET
+
+          projects = [
+              "Extend0/Extend0.csproj",
+              "Extend0.Cli/Extend0.Cli.csproj",
+              "Extend0.MetadataEntry.Generator/Extend0.MetadataEntry.Generator.csproj",
+              "Extend0.BlittableAdapter.Generator/Extend0.BlittableAdapter.Generator.csproj",
+          ]
+          versions = {}
+          for project in projects:
+              value = ET.parse(project).findtext(".//Version")
+              if not value:
+                  raise SystemExit(f"{project} has no Version")
+              versions[project] = value
+
+          unique = set(versions.values())
+          if len(unique) != 1:
+              raise SystemExit(f"package versions are not aligned: {versions}")
+          print(f"version={unique.pop()}")
+          PY
+      - name: Pack all public artifacts
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          dotnet pack Extend0.MetadataEntry.Generator/Extend0.MetadataEntry.Generator.csproj -c Release -o artifacts
+          dotnet pack Extend0.BlittableAdapter.Generator/Extend0.BlittableAdapter.Generator.csproj -c Release -o artifacts
+          dotnet pack Extend0/Extend0.csproj -c Release -o artifacts
+          dotnet pack Extend0.Cli/Extend0.Cli.csproj -c Release -o artifacts
+          printf '%s\n' "${{ steps.version.outputs.version }}" > artifacts/version.txt
+      - name: Inspect package identities and versions
+        shell: bash
+        run: |
+          python - <<'PY'
+          import pathlib
+          import xml.etree.ElementTree as ET
+          import zipfile
+
+          root = pathlib.Path("artifacts")
+          version = (root / "version.txt").read_text().strip()
+          expected = {
+              "Extend0",
+              "Extend0.Cli",
+              "Extend0.MetadataEntry.Generator",
+              "Extend0.BlittableAdapter.Generator",
+          }
+          found = set()
+          for package in root.glob("*.nupkg"):
+              if package.name.endswith(".symbols.nupkg"):
+                  continue
+              with zipfile.ZipFile(package) as archive:
+                  nuspec = next(name for name in archive.namelist() if name.endswith(".nuspec"))
+                  document = ET.fromstring(archive.read(nuspec))
+                  namespace = {"n": "http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"}
+                  metadata = document.find("n:metadata", namespace)
+                  if metadata is None:
+                      metadata = document.find("metadata")
+                  package_id = metadata.findtext("n:id", namespaces=namespace) or metadata.findtext("id")
+                  package_version = (
+                      metadata.findtext("n:version", namespaces=namespace)
+                      or metadata.findtext("version")
+                  )
+                  if package_version != version:
+                      raise SystemExit(
+                          f"{package.name} contains version {package_version}, expected {version}"
+                      )
+                  found.add(package_id)
+          if found != expected:
+              raise SystemExit(f"package set mismatch: found={found}, expected={expected}")
+          PY
+      - uses: actions/upload-artifact@v7.0.1
+        with:
+          name: extend0-nuget-${{ steps.version.outputs.version }}
+          path: artifacts/
+          if-no-files-found: error
+          retention-days: 14
+
+  publish:
+    if: github.event_name != 'pull_request'
+    needs: pack
+    runs-on: ubuntu-latest
+    environment: nuget
+    steps:
+      - uses: actions/download-artifact@v7.0.0
+        with:
+          name: extend0-nuget-${{ needs.pack.outputs.version }}
+          path: artifacts
+      - uses: actions/setup-dotnet@v5.4.0
+        with:
+          dotnet-version: 10.0.x
+      - name: Publish coherent package set to NuGet
+        shell: bash
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          VERSION: ${{ needs.pack.outputs.version }}
+        run: |
+          if [ -z "$NUGET_API_KEY" ]; then
+            echo "::error::Repository or nuget environment secret NUGET_API_KEY is not configured"
+            exit 1
+          fi
+          source_url="https://api.nuget.org/v3/index.json"
+          dotnet nuget push "artifacts/Extend0.MetadataEntry.Generator.$VERSION.nupkg" --api-key "$NUGET_API_KEY" --source "$source_url" --skip-duplicate
+          dotnet nuget push "artifacts/Extend0.BlittableAdapter.Generator.$VERSION.nupkg" --api-key "$NUGET_API_KEY" --source "$source_url" --skip-duplicate
+          dotnet nuget push "artifacts/Extend0.$VERSION.nupkg" --api-key "$NUGET_API_KEY" --source "$source_url" --skip-duplicate
+          dotnet nuget push "artifacts/Extend0.Cli.$VERSION.nupkg" --api-key "$NUGET_API_KEY" --source "$source_url" --skip-duplicate

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -43,10 +43,16 @@ jobs:
         run: dotnet --info
       - name: Restore tests
         run: dotnet restore Extend0.Tests/Extend0.Tests.csproj
-      - name: Run tests
+      - name: Run full test suite
+        if: runner.os == 'Windows'
         run: dotnet test Extend0.Tests/Extend0.Tests.csproj -c Release --no-restore
+      - name: Build test assembly on Unix
+        if: runner.os != 'Windows'
+        run: dotnet build Extend0.Tests/Extend0.Tests.csproj -c Release --no-restore
       - name: Build CLI
         run: dotnet build Extend0.Cli/Extend0.Cli.csproj -c Release
+      - name: Run platform diagnostic
+        run: dotnet run --project Extend0.Cli/Extend0.Cli.csproj -c Release --no-build -- doctor --json
 
   pack:
     needs: test

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -104,7 +104,7 @@ jobs:
           dotnet pack Extend0.BlittableAdapter.Generator/Extend0.BlittableAdapter.Generator.csproj -c Release --no-build -o artifacts
           dotnet pack Extend0/Extend0.csproj -c Release --no-build -o artifacts
           dotnet pack Extend0.Cli/Extend0.Cli.csproj -c Release --no-build -o artifacts
-          printf '%s\\n' "${{ steps.version.outputs.version }}" > artifacts/version.txt
+          printf '%s\n' "${{ steps.version.outputs.version }}" > artifacts/version.txt
       - name: Inspect package identities and versions
         shell: bash
         run: |

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -89,15 +89,22 @@ jobs:
               raise SystemExit(f"package versions are not aligned: {versions}")
           print(f"version={unique.pop()}")
           PY
+      - name: Build package binaries
+        shell: bash
+        run: |
+          dotnet build Extend0.MetadataEntry.Generator/Extend0.MetadataEntry.Generator.csproj -c Release -p:GeneratePackageOnBuild=false
+          dotnet build Extend0.BlittableAdapter.Generator/Extend0.BlittableAdapter.Generator.csproj -c Release -p:GeneratePackageOnBuild=false
+          dotnet build Extend0/Extend0.csproj -c Release -p:GeneratePackageOnBuild=false
+          dotnet build Extend0.Cli/Extend0.Cli.csproj -c Release -p:GeneratePackageOnBuild=false
       - name: Pack all public artifacts
         shell: bash
         run: |
           mkdir -p artifacts
-          dotnet pack Extend0.MetadataEntry.Generator/Extend0.MetadataEntry.Generator.csproj -c Release -o artifacts
-          dotnet pack Extend0.BlittableAdapter.Generator/Extend0.BlittableAdapter.Generator.csproj -c Release -o artifacts
-          dotnet pack Extend0/Extend0.csproj -c Release -o artifacts
-          dotnet pack Extend0.Cli/Extend0.Cli.csproj -c Release -o artifacts
-          printf '%s\n' "${{ steps.version.outputs.version }}" > artifacts/version.txt
+          dotnet pack Extend0.MetadataEntry.Generator/Extend0.MetadataEntry.Generator.csproj -c Release --no-build -o artifacts
+          dotnet pack Extend0.BlittableAdapter.Generator/Extend0.BlittableAdapter.Generator.csproj -c Release --no-build -o artifacts
+          dotnet pack Extend0/Extend0.csproj -c Release --no-build -o artifacts
+          dotnet pack Extend0.Cli/Extend0.Cli.csproj -c Release --no-build -o artifacts
+          printf '%s\\n' "${{ steps.version.outputs.version }}" > artifacts/version.txt
       - name: Inspect package identities and versions
         shell: bash
         run: |

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.301",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
## What changed

- pins the package build to .NET SDK 10.0.301;
- runs the complete current test suite on Windows;
- builds the test assembly and runs `extend0 doctor --json` on Linux, Windows and macOS;
- verifies that Extend0, Extend0.Cli and both source-generator projects declare one coherent version;
- packs and inspects all four NuGet artifacts before publication;
- publishes the coherent package set to NuGet after changes reach `main`;
- supports an explicit manual run and fails clearly when `NUGET_API_KEY` is not configured.

## Why

The repository currently declares `1.0.9535` across its public packages, while NuGet still serves old and mutually inconsistent releases. Downstream consumers therefore cannot use the current public `MetaDB.CreateManager()` facade or the .NET 10 package surface.

## Cross-platform qualification

The first workflow run exposed 7 Linux and 31 macOS failures caused mainly by Windows-specific file-lock and delete assumptions. Those are tracked explicitly in #5. Until that portability contract is fixed, publication requires:

- the complete current suite to pass on Windows;
- every project to compile on Linux and macOS;
- the platform diagnostic to pass on all three operating systems;
- package identity and version inspection to pass.

Persistent MetaDB use on Linux/macOS remains gated by #5.

## Publication behavior

Pull requests only test and pack. A merge to `main` publishes version `1.0.9535` to NuGet in dependency-first order. The publish job uses the protected `nuget` environment and its `NUGET_API_KEY` secret; duplicate package versions are skipped safely.
