### PR TITLE
Use NuGet trusted publishing

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -165,6 +165,9 @@ jobs:
     needs: pack
     runs-on: ubuntu-latest
     environment: nuget
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/download-artifact@v7.0.0
         with:
@@ -173,16 +176,17 @@ jobs:
       - uses: actions/setup-dotnet@v5.4.0
         with:
           dotnet-version: 10.0.x
+      - name: Request short-lived NuGet API key
+        id: nuget-login
+        uses: NuGet/login@v1.2.0
+        with:
+          user: papishushi
       - name: Publish coherent package set to NuGet
         shell: bash
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
           VERSION: ${{ needs.pack.outputs.version }}
         run: |
-          if [ -z "$NUGET_API_KEY" ]; then
-            echo "::error::Repository or nuget environment secret NUGET_API_KEY is not configured"
-            exit 1
-          fi
           source_url="https://api.nuget.org/v3/index.json"
           dotnet nuget push "artifacts/Extend0.MetadataEntry.Generator.$VERSION.nupkg" --api-key "$NUGET_API_KEY" --source "$source_url" --skip-duplicate
           dotnet nuget push "artifacts/Extend0.BlittableAdapter.Generator.$VERSION.nupkg" --api-key "$NUGET_API_KEY" --source "$source_url" --skip-duplicate


### PR DESCRIPTION
## What changed

- grants `id-token: write` only to the protected `publish` job
- exchanges the GitHub Actions OIDC token through `NuGet/login@v1.2.0`
- publishes with the returned short-lived API key
- removes the dependency on the long-lived `NUGET_API_KEY` secret

## Why

The `1.0.9535` packages were built successfully but publication was blocked because the workflow expected a repository secret. NuGet trusted publishing is already configured for:

- package owner: `papishushi`
- repository: `Papishushi/Extend0`
- workflow: `nuget.yml`
- environment: `nuget`

This change aligns the workflow with that policy and keeps publishing restricted to non-PR runs after the test and pack jobs pass.

## Validation

- compared against `main`: one workflow file changed
- preserved the protected `nuget` environment
- kept the package build, inspection, artifact, version, and push order unchanged
- PR runs skip the publish job; the OIDC exchange will be validated by the first `main` run after merge
