### PR TITLE
Fix portable MetaDB ownership and IPC endpoint semantics

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -3,19 +3,25 @@ name: NuGet packages
 on:
   pull_request:
     paths:
-      - "Extend0/Extend0.csproj"
-      - "Extend0.Cli/Extend0.Cli.csproj"
-      - "Extend0.MetadataEntry.Generator/Extend0.MetadataEntry.Generator.csproj"
-      - "Extend0.BlittableAdapter.Generator/Extend0.BlittableAdapter.Generator.csproj"
+      - "Extend0/**"
+      - "Extend0.Cli/**"
+      - "Extend0.MetadataEntry.Generator/**"
+      - "Extend0.BlittableAdapter.Generator/**"
+      - "Extend0.Testing/**"
+      - "Extend0.Tests/**"
+      - "Extend0.TestProcessHost/**"
       - "global.json"
       - ".github/workflows/nuget.yml"
   push:
     branches: [main]
     paths:
-      - "Extend0/Extend0.csproj"
-      - "Extend0.Cli/Extend0.Cli.csproj"
-      - "Extend0.MetadataEntry.Generator/Extend0.MetadataEntry.Generator.csproj"
-      - "Extend0.BlittableAdapter.Generator/Extend0.BlittableAdapter.Generator.csproj"
+      - "Extend0/**"
+      - "Extend0.Cli/**"
+      - "Extend0.MetadataEntry.Generator/**"
+      - "Extend0.BlittableAdapter.Generator/**"
+      - "Extend0.Testing/**"
+      - "Extend0.Tests/**"
+      - "Extend0.TestProcessHost/**"
       - "global.json"
       - ".github/workflows/nuget.yml"
   workflow_dispatch:
@@ -44,11 +50,7 @@ jobs:
       - name: Restore tests
         run: dotnet restore Extend0.Tests/Extend0.Tests.csproj
       - name: Run full test suite
-        if: runner.os == 'Windows'
         run: dotnet test Extend0.Tests/Extend0.Tests.csproj -c Release --no-restore
-      - name: Build test assembly on Unix
-        if: runner.os != 'Windows'
-        run: dotnet build Extend0.Tests/Extend0.Tests.csproj -c Release --no-restore
       - name: Build CLI
         run: dotnet build Extend0.Cli/Extend0.Cli.csproj -c Release
       - name: Run platform diagnostic

--- a/Extend0.TestProcessHost/Extend0.TestProcessHost.csproj
+++ b/Extend0.TestProcessHost/Extend0.TestProcessHost.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Extend0.Testing\Extend0.Testing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Extend0.TestProcessHost/Program.cs
+++ b/Extend0.TestProcessHost/Program.cs
@@ -1,0 +1,24 @@
+using Extend0.Metadata.Schema;
+using Extend0.Testing.Metadata.Storage;
+
+if (args.Length != 4 || !string.Equals(args[0], "hold-mapped-store", StringComparison.Ordinal))
+{
+    Console.Error.WriteLine("Usage: Extend0.TestProcessHost hold-mapped-store <map-path> <ready-path> <release-path>");
+    return 64;
+}
+
+var mapPath = args[1];
+var readyPath = args[2];
+var releasePath = args[3];
+var spec = new TableSpec(
+    "CrossProcessLease",
+    mapPath,
+    [TableSpec.Helpers.Column("Value", 1, valueBytes: 64)]);
+
+using var store = MetadataStorageHarness.CreateMappedStore(spec);
+File.WriteAllText(readyPath, Environment.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+while (!File.Exists(releasePath))
+    await Task.Delay(10).ConfigureAwait(false);
+
+return 0;

--- a/Extend0.Testing/Metadata/Internal/MetaDBManagerHarness.cs
+++ b/Extend0.Testing/Metadata/Internal/MetaDBManagerHarness.cs
@@ -142,6 +142,12 @@ public static class MetaDBManagerHarness
         ILogger? logger = null,
         Func<TableSpec?, IMetadataTable>? factory = null,
         CapacityPolicy capacityPolicy = CapacityPolicy.Throw,
-        string? deleteQueuePath = null) =>
-        new(new MetaDBManager(logger, factory ?? (spec => MetadataTableHarness.CreateTable(spec!.Value)), capacityPolicy, deleteQueuePath));
+        string? deleteQueuePath = null,
+        bool startDeleteWorker = true) =>
+        new(new MetaDBManager(
+            logger,
+            factory ?? (spec => MetadataTableHarness.CreateTable(spec!.Value)),
+            capacityPolicy,
+            deleteQueuePath,
+            startDeleteWorker));
 }

--- a/Extend0.Testing/Metadata/Storage/MetadataStorageHarness.cs
+++ b/Extend0.Testing/Metadata/Storage/MetadataStorageHarness.cs
@@ -46,6 +46,9 @@ public static class MetadataStorageHarness
     public static ICellStore CreateMappedStore(TableSpec spec) =>
         new MappedStore(spec);
 
+    public static IDisposable AcquireStorageLease(string path) =>
+        MetadataStorageLease.Acquire(path);
+
     public static bool TryLoadMappedColumns(string path, out ColumnConfiguration[] columns) =>
         MappedStore.TryLoadColumns(path, out columns);
 

--- a/Extend0.Tests/Extend0.Tests.csproj
+++ b/Extend0.Tests/Extend0.Tests.csproj
@@ -32,6 +32,16 @@
     <ProjectReference Include="..\Extend0.Cli\Extend0.Cli.csproj" />
     <ProjectReference Include="..\Extend0.MetadataEntry.Generator\Extend0.MetadataEntry.Generator.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\Extend0.Testing\Extend0.Testing.csproj" />
+    <ProjectReference Include="..\Extend0.TestProcessHost\Extend0.TestProcessHost.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
+
+  <Target Name="CopyTestProcessHost" AfterTargets="Build">
+    <ItemGroup>
+      <_TestProcessHostFiles Include="$(MSBuildProjectDirectory)\..\Extend0.TestProcessHost\bin\$(Configuration)\net10.0\*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_TestProcessHostFiles)"
+          DestinationFolder="$(OutDir)process-host"
+          SkipUnchangedFiles="true" />
+  </Target>
 
 </Project>

--- a/Extend0.Tests/Lifecycle/CrossProcess/CrossProcessOrchestratorTests.cs
+++ b/Extend0.Tests/Lifecycle/CrossProcess/CrossProcessOrchestratorTests.cs
@@ -35,7 +35,7 @@ public sealed class CrossProcessOrchestratorTests
         Assert.Equal(".", result.EndpointServerName);
         Assert.Equal(TransportKind.NamedPipe, result.TransportKind);
         Assert.Equal(LifecycleCrossProcessHarness.BuildTestServiceOwnershipName(serviceName), result.OwnershipName);
-        Assert.Equal("OSMutex", result.CoordinationKind);
+        Assert.Equal(OperatingSystem.IsWindows() ? "OSMutex" : "OSFileLease", result.CoordinationKind);
         Assert.False(string.IsNullOrWhiteSpace(result.CoordinationScope));
         Assert.True(result.LeaseIsExclusive);
         Assert.True(result.LeaseIsActive);

--- a/Extend0.Tests/Lifecycle/CrossProcess/CrossProcessServiceBaseTests.cs
+++ b/Extend0.Tests/Lifecycle/CrossProcess/CrossProcessServiceBaseTests.cs
@@ -1,4 +1,5 @@
 using Extend0.Lifecycle.CrossProcess;
+using Extend0.Testing.Lifecycle.CrossProcess;
 using Microsoft.Extensions.Logging;
 using System.IO.Pipes;
 
@@ -19,7 +20,7 @@ public sealed class CrossProcessServiceBaseTests
     [Fact]
     public async Task CanConnectAsync_DefaultProbe_ReturnsTrue_WhenNamedPipeServerIsListening()
     {
-        var pipeName = $"extend0-probe-{Guid.NewGuid():N}";
+        var pipeName = LifecycleCrossProcessHarness.BuildNamedPipeEndpointName($"extend0-probe-{Guid.NewGuid():N}");
         using var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
         var waitServer = server.WaitForConnectionAsync();
         var service = new DefaultProbeTestService(pipeName);

--- a/Extend0.Tests/Lifecycle/CrossProcess/CrossProcessTransportFactoryTests.cs
+++ b/Extend0.Tests/Lifecycle/CrossProcess/CrossProcessTransportFactoryTests.cs
@@ -81,12 +81,19 @@ public sealed class CrossProcessTransportFactoryTests
         var namedPipeEndpoint = CrossProcessTransportFactory.ResolveEndpointName(
             "Extend0.Test.Service",
             TransportKind.NamedPipe);
+        var explicitNamedPipeEndpoint = CrossProcessTransportFactory.ResolveEndpointName(
+            "ignored",
+            TransportKind.NamedPipe,
+            explicitEndpointName: "a-human-readable-but-potentially-long-pipe-name");
         var unixDomainSocketEndpoint = CrossProcessTransportFactory.ResolveEndpointName(
             "Extend0.Test.Service",
             TransportKind.UnixDomainSocket);
 
         Assert.Equal("explicit-endpoint", explicitEndpoint);
         Assert.Equal(LifecycleCrossProcessHarness.BuildNamedPipeEndpointName("Extend0.Test.Service"), namedPipeEndpoint);
+        Assert.Equal(
+            LifecycleCrossProcessHarness.BuildNamedPipeEndpointName("a-human-readable-but-potentially-long-pipe-name"),
+            explicitNamedPipeEndpoint);
         Assert.Equal(LifecycleCrossProcessHarness.BuildUnixDomainSocketEndpointName("Extend0.Test.Service"), unixDomainSocketEndpoint);
         Assert.EndsWith(".sock", unixDomainSocketEndpoint, StringComparison.Ordinal);
         Assert.Throws<NotSupportedException>(() => CrossProcessTransportFactory.ResolveEndpointName("tcp", TransportKind.TcpSocket));

--- a/Extend0.Tests/Lifecycle/CrossProcess/CrossProcessUtilsTests.cs
+++ b/Extend0.Tests/Lifecycle/CrossProcess/CrossProcessUtilsTests.cs
@@ -37,7 +37,8 @@ public sealed class CrossProcessUtilsTests
         Assert.Matches("^[A-Za-z0-9._-]+$", shortName);
         Assert.StartsWith("P.", longName, StringComparison.Ordinal);
         Assert.Contains('.', longName);
-        Assert.True(longName.Length < 220);
+        Assert.Equal(shortName.Length, longName.Length);
+        Assert.True(longName.Length <= 36);
     }
 
     [Fact]

--- a/Extend0.Tests/Lifecycle/CrossProcess/NamedPipeTransportTests.cs
+++ b/Extend0.Tests/Lifecycle/CrossProcess/NamedPipeTransportTests.cs
@@ -245,7 +245,7 @@ public sealed class NamedPipeTransportTests
     [Fact]
     public async Task NamedPipeClientTransport_RejectsInvalidHandshake()
     {
-        var pipeName = $"Extend0.Tests.BadHandshake.{Guid.NewGuid():N}";
+        var pipeName = LifecycleCrossProcessHarness.BuildNamedPipeEndpointName($"Extend0.Tests.BadHandshake.{Guid.NewGuid():N}");
         var serverTask = RunRawServerAsync(
             pipeName,
             static async server =>
@@ -266,7 +266,7 @@ public sealed class NamedPipeTransportTests
     [Fact]
     public async Task NamedPipeClientTransport_RejectsMissingGreeting()
     {
-        var pipeName = $"Extend0.Tests.MissingHello.{Guid.NewGuid():N}";
+        var pipeName = LifecycleCrossProcessHarness.BuildNamedPipeEndpointName($"Extend0.Tests.MissingHello.{Guid.NewGuid():N}");
         var serverTask = RunRawServerAsync(
             pipeName,
             static server =>
@@ -287,7 +287,7 @@ public sealed class NamedPipeTransportTests
     [Fact]
     public async Task NamedPipeClientTransport_ReturnsSoftErrors_ForMalformedJsonAndClosedTransport()
     {
-        var malformedPipe = $"Extend0.Tests.MalformedJson.{Guid.NewGuid():N}";
+        var malformedPipe = LifecycleCrossProcessHarness.BuildNamedPipeEndpointName($"Extend0.Tests.MalformedJson.{Guid.NewGuid():N}");
         var malformedServerTask = RunRawServerAsync(
             malformedPipe,
             async server =>
@@ -308,7 +308,7 @@ public sealed class NamedPipeTransportTests
 
         await malformedServerTask;
 
-        var closedPipe = $"Extend0.Tests.ClosedTransport.{Guid.NewGuid():N}";
+        var closedPipe = LifecycleCrossProcessHarness.BuildNamedPipeEndpointName($"Extend0.Tests.ClosedTransport.{Guid.NewGuid():N}");
         var closedServerTask = RunRawServerAsync(
             closedPipe,
             async server =>
@@ -326,7 +326,7 @@ public sealed class NamedPipeTransportTests
 
         await closedServerTask;
 
-        var eofPipe = $"Extend0.Tests.EofTransport.{Guid.NewGuid():N}";
+        var eofPipe = LifecycleCrossProcessHarness.BuildNamedPipeEndpointName($"Extend0.Tests.EofTransport.{Guid.NewGuid():N}");
         var eofServerTask = RunRawServerAsync(
             eofPipe,
             async server =>
@@ -350,7 +350,7 @@ public sealed class NamedPipeTransportTests
     [Fact]
     public async Task NamedPipeClientTransport_ReturnsSoftError_WhenCalledAfterDispose()
     {
-        var pipeName = $"Extend0.Tests.DisposedTransport.{Guid.NewGuid():N}";
+        var pipeName = LifecycleCrossProcessHarness.BuildNamedPipeEndpointName($"Extend0.Tests.DisposedTransport.{Guid.NewGuid():N}");
         var serverTask = RunRawServerAsync(
             pipeName,
             async server =>
@@ -390,7 +390,7 @@ public sealed class NamedPipeTransportTests
     [Fact]
     public async Task NamedPipeClientTransport_PropagatesReadCancellation()
     {
-        var pipeName = $"Extend0.Tests.CancellableRead.{Guid.NewGuid():N}";
+        var pipeName = LifecycleCrossProcessHarness.BuildNamedPipeEndpointName($"Extend0.Tests.CancellableRead.{Guid.NewGuid():N}");
         var serverTask = RunRawServerAsync(
             pipeName,
             async server =>

--- a/Extend0.Tests/Metadata/CrossProcess/MetaDBManagerSingletonTests.cs
+++ b/Extend0.Tests/Metadata/CrossProcess/MetaDBManagerSingletonTests.cs
@@ -6,6 +6,7 @@ using Extend0.Testing.Metadata.Internal;
 
 namespace Extend0.Tests.Metadata.CrossProcess;
 
+[Collection(Extend0.Tests.Metadata.Storage.MappedStorageCollection.Name)]
 public sealed class MetaDBManagerSingletonTests
 {
     [Fact]

--- a/Extend0.Tests/Metadata/Internal/MetaDBManagerHelpersTests.cs
+++ b/Extend0.Tests/Metadata/Internal/MetaDBManagerHelpersTests.cs
@@ -6,6 +6,7 @@ using Extend0.Metadata.Schema;
 using Extend0.Metadata.Storage;
 using Extend0.Metadata.Storage.Contract;
 using Extend0.Testing.Metadata.Internal;
+using Extend0.Testing.Metadata.Storage;
 
 namespace Extend0.Tests.Metadata.Internal;
 
@@ -160,7 +161,7 @@ public sealed class MetaDBManagerHelpersTests
             var lockedPath = Path.Combine(tempRoot, "locked.bin");
             File.WriteAllText(lockedPath, "locked");
 
-            using var lockHandle = new FileStream(lockedPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            using var lockHandle = MetadataStorageHarness.AcquireStorageLease(lockedPath);
             var deleted = await MetaDBManagerHelpersHarness.TryDeleteWithRetries(lockedPath, attempts: 2);
 
             Assert.False(deleted);

--- a/Extend0.Tests/Metadata/Internal/MetadataTableTests.cs
+++ b/Extend0.Tests/Metadata/Internal/MetadataTableTests.cs
@@ -1,5 +1,6 @@
 using Extend0.Metadata;
 using Extend0.Metadata.Contract;
+using Extend0.Metadata.Diagnostics;
 using Extend0.Metadata.Indexing.Contract;
 using Extend0.Metadata.Schema;
 using Extend0.Tests.Metadata.Storage;
@@ -384,7 +385,7 @@ public sealed class MetadataTableTests
                 var cell = table.GetOrCreateCell(0, 0);
                 Assert.True(cell.TrySetKey("alpha"));
 
-                Assert.ThrowsAny<IOException>(() => table.Open());
+                Assert.Throws<MetadataTableLockedException>(() => table.Open());
             }
 
             using var reopened = MetadataTableHarness.OpenTable(spec);

--- a/Extend0.Tests/Metadata/MetaDBManagerBehaviorTests.cs
+++ b/Extend0.Tests/Metadata/MetaDBManagerBehaviorTests.cs
@@ -5,6 +5,7 @@ using Extend0.Metadata.Schema;
 using Extend0.Metadata.Storage;
 using Extend0.Testing.Metadata.Indexing.Registries;
 using Extend0.Testing.Metadata.Internal;
+using Extend0.Testing.Metadata.Storage;
 using Extend0.Tests.Metadata.Storage;
 using Extend0.Tests.TestUtilities;
 using Microsoft.Extensions.Logging;
@@ -669,11 +670,14 @@ public sealed class MetaDBManagerBehaviorTests
             var secondPath = Path.Combine(tempRoot, "second.map");
             File.WriteAllText(firstPath, "first");
             File.WriteAllText(secondPath, "second");
-            using var firstLock = new FileStream(firstPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
-            using var secondLock = new FileStream(secondPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            using var firstLock = MetadataStorageHarness.AcquireStorageLease(firstPath);
+            using var secondLock = MetadataStorageHarness.AcquireStorageLease(secondPath);
             File.WriteAllText(queuePath, "  " + firstPath + "  " + Environment.NewLine + Environment.NewLine + secondPath + Environment.NewLine);
 
-            using var loaded = MetaDBManagerHarness.CreateManager(factory: _ => MetadataTableHarness.CreateTable(CreateSupportedSpec("Loaded", 1)), deleteQueuePath: queuePath);
+            using var loaded = MetaDBManagerHarness.CreateManager(
+                factory: _ => MetadataTableHarness.CreateTable(CreateSupportedSpec("Loaded", 1)),
+                deleteQueuePath: queuePath,
+                startDeleteWorker: false);
             Assert.Equal([firstPath, secondPath], loaded.GetPendingDeletePaths());
 
             var thirdPath = Path.Combine(tempRoot, "third.map");
@@ -754,8 +758,8 @@ public sealed class MetaDBManagerBehaviorTests
             await File.WriteAllTextAsync(lockedMapPath, "map");
             await File.WriteAllTextAsync(lockedSpecPath, "spec");
 
-            using var mapLock = new FileStream(lockedMapPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
-            using var specLock = new FileStream(lockedSpecPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            using var mapLock = MetadataStorageHarness.AcquireStorageLease(lockedMapPath);
+            using var specLock = MetadataStorageHarness.AcquireStorageLease(lockedSpecPath);
 
             var lockedDelete = await handle.TryDeleteNow(lockedMapPath, lockedSpecPath, Guid.NewGuid());
 
@@ -825,14 +829,21 @@ public sealed class MetaDBManagerBehaviorTests
 
             var deleted = await handle.TryDeleteNow(mapPath, specPath, Guid.NewGuid());
             var pending = handle.GetPendingDeletePaths();
-            var movedPath = Assert.Single(pending, path => path.Contains(".deleting.", StringComparison.Ordinal));
-
-            Assert.False(deleted);
             Assert.False(File.Exists(mapPath));
-            Assert.StartsWith(mapPath + ".deleting.", movedPath, StringComparison.Ordinal);
-            Assert.True(File.Exists(movedPath));
-
-            File.SetAttributes(movedPath, FileAttributes.Normal);
+            if (OperatingSystem.IsWindows())
+            {
+                var movedPath = Assert.Single(pending, path => path.Contains(".deleting.", StringComparison.Ordinal));
+                Assert.False(deleted);
+                Assert.StartsWith(mapPath + ".deleting.", movedPath, StringComparison.Ordinal);
+                Assert.True(File.Exists(movedPath));
+                File.SetAttributes(movedPath, FileAttributes.Normal);
+            }
+            else
+            {
+                // Unix deletion is controlled by directory permissions, not the file's read-only bit.
+                Assert.True(deleted);
+                Assert.Empty(pending);
+            }
         }
         finally
         {
@@ -857,8 +868,8 @@ public sealed class MetaDBManagerBehaviorTests
             await File.WriteAllTextAsync(mapPath, "map");
             await File.WriteAllTextAsync(specPath, "spec");
 
-            using var mapLock = new FileStream(mapPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
-            using var specLock = new FileStream(specPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            using var mapLock = MetadataStorageHarness.AcquireStorageLease(mapPath);
+            using var specLock = MetadataStorageHarness.AcquireStorageLease(specPath);
 
             await handle.CleanupEphemeralDeleteAsync(throwIfDeleteFails: false, Guid.NewGuid(), mapPath, specPath);
             Assert.Contains(mapPath, handle.GetPendingDeletePaths());
@@ -999,7 +1010,7 @@ public sealed class MetaDBManagerBehaviorTests
             spec.SaveToFile(mapPath + ".tablespec.json");
             File.WriteAllBytes(mapPath, [0]);
 
-            using var mapLock = new FileStream(mapPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            using var mapLock = MetadataStorageHarness.AcquireStorageLease(mapPath);
             using var handle = MetaDBManagerHarness.CreateManager();
             var manager = handle.Contract;
 

--- a/Extend0.Tests/Metadata/Storage/MappedStoreTests.cs
+++ b/Extend0.Tests/Metadata/Storage/MappedStoreTests.cs
@@ -607,29 +607,9 @@ public sealed class MappedStoreTests
             var releasePath = Path.Combine(tempRoot, "owner.release");
             var spec = new TableSpec("CrossProcessLease", mapPath, [TableSpec.Helpers.Column("Value", 1, valueBytes: 64)]);
 
-            using (MetadataStorageHarness.CreateMappedStore(spec))
-            {
-            }
+            MetadataStorageHarness.CreateMappedStore(spec).Dispose();
 
-            var hostAssembly = Path.Combine(
-                AppContext.BaseDirectory,
-                "process-host",
-                "Extend0.TestProcessHost.dll");
-            Assert.True(File.Exists(hostAssembly), $"Cross-process test host was not found at '{hostAssembly}'.");
-
-            var startInfo = new ProcessStartInfo("dotnet")
-            {
-                RedirectStandardError = true,
-                RedirectStandardOutput = true,
-                UseShellExecute = false
-            };
-            startInfo.ArgumentList.Add(hostAssembly);
-            startInfo.ArgumentList.Add("hold-mapped-store");
-            startInfo.ArgumentList.Add(mapPath);
-            startInfo.ArgumentList.Add(readyPath);
-            startInfo.ArgumentList.Add(releasePath);
-
-            owner = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start the cross-process lease test host.");
+            owner = StartMappedStoreOwner(mapPath, readyPath, releasePath);
             await WaitForFileOrProcessExit(owner, readyPath, TimeSpan.FromSeconds(15));
 
             var openFailure = Assert.Throws<MetadataTableLockedException>(() => MetadataStorageHarness.CreateMappedStore(spec));
@@ -657,6 +637,30 @@ public sealed class MappedStoreTests
             owner?.Dispose();
             Directory.Delete(tempRoot, recursive: true);
         }
+    }
+
+    private static Process StartMappedStoreOwner(string mapPath, string readyPath, string releasePath)
+    {
+        var hostAssembly = Path.Combine(
+            AppContext.BaseDirectory,
+            "process-host",
+            "Extend0.TestProcessHost.dll");
+        Assert.True(File.Exists(hostAssembly), $"Cross-process test host was not found at '{hostAssembly}'.");
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add(hostAssembly);
+        startInfo.ArgumentList.Add("hold-mapped-store");
+        startInfo.ArgumentList.Add(mapPath);
+        startInfo.ArgumentList.Add(readyPath);
+        startInfo.ArgumentList.Add(releasePath);
+
+        return Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start the cross-process lease test host.");
     }
 
     private static async Task WaitForFileOrProcessExit(Process process, string path, TimeSpan timeout)

--- a/Extend0.Tests/Metadata/Storage/MappedStoreTests.cs
+++ b/Extend0.Tests/Metadata/Storage/MappedStoreTests.cs
@@ -3,7 +3,9 @@ using Extend0.Metadata.Diagnostics;
 using Extend0.Metadata.Schema;
 using Extend0.Metadata.Storage;
 using Extend0.Metadata.Storage.Contract;
+using Extend0.Testing.Metadata.Internal;
 using Extend0.Testing.Metadata.Storage;
+using System.Diagnostics;
 
 namespace Extend0.Tests.Metadata.Storage;
 
@@ -571,7 +573,7 @@ public sealed class MappedStoreTests
     }
 
     [Fact]
-    public void MappedStore_Create_TranslatesRealExclusiveFileLockToMetadataTableLockedException()
+    public void MappedStore_Create_TranslatesPortableStorageLeaseContentionToMetadataTableLockedException()
     {
         var tempRoot = CreateTempDirectory();
         try
@@ -580,7 +582,7 @@ public sealed class MappedStoreTests
             var spec = new TableSpec("LockedOpen", mapPath, [TableSpec.Helpers.Column("Name", 1, valueBytes: 64)]);
             File.WriteAllBytes(mapPath, [0]);
 
-            using var exclusiveLock = new FileStream(mapPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            using var exclusiveLock = MetadataStorageHarness.AcquireStorageLease(mapPath);
 
             var ex = Assert.Throws<MetadataTableLockedException>(() => MetadataStorageHarness.CreateMappedStore(spec));
 
@@ -591,6 +593,85 @@ public sealed class MappedStoreTests
         {
             Directory.Delete(tempRoot, recursive: true);
         }
+    }
+
+    [Fact]
+    public async Task MappedStore_CrossProcessLease_BlocksOpenAndDeleteUntilOwnerExits()
+    {
+        var tempRoot = CreateTempDirectory();
+        Process? owner = null;
+        try
+        {
+            var mapPath = Path.Combine(tempRoot, "cross-process.map");
+            var readyPath = Path.Combine(tempRoot, "owner.ready");
+            var releasePath = Path.Combine(tempRoot, "owner.release");
+            var spec = new TableSpec("CrossProcessLease", mapPath, [TableSpec.Helpers.Column("Value", 1, valueBytes: 64)]);
+
+            using (MetadataStorageHarness.CreateMappedStore(spec))
+            {
+            }
+
+            var hostAssembly = Path.Combine(
+                AppContext.BaseDirectory,
+                "process-host",
+                "Extend0.TestProcessHost.dll");
+            Assert.True(File.Exists(hostAssembly), $"Cross-process test host was not found at '{hostAssembly}'.");
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false
+            };
+            startInfo.ArgumentList.Add(hostAssembly);
+            startInfo.ArgumentList.Add("hold-mapped-store");
+            startInfo.ArgumentList.Add(mapPath);
+            startInfo.ArgumentList.Add(readyPath);
+            startInfo.ArgumentList.Add(releasePath);
+
+            owner = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start the cross-process lease test host.");
+            await WaitForFileOrProcessExit(owner, readyPath, TimeSpan.FromSeconds(15));
+
+            var openFailure = Assert.Throws<MetadataTableLockedException>(() => MetadataStorageHarness.CreateMappedStore(spec));
+            Assert.IsAssignableFrom<IOException>(openFailure.InnerException);
+
+            var deleted = await MetaDBManagerHelpersHarness.TryDeleteWithRetries(mapPath, attempts: 2);
+            Assert.False(deleted);
+            Assert.True(File.Exists(mapPath));
+
+            File.WriteAllText(releasePath, "release");
+            using var exitTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            await owner.WaitForExitAsync(exitTimeout.Token);
+            Assert.Equal(0, owner.ExitCode);
+
+            using var reopened = MetadataStorageHarness.CreateMappedStore(spec);
+        }
+        finally
+        {
+            if (owner is { HasExited: false })
+            {
+                owner.Kill(entireProcessTree: true);
+                await owner.WaitForExitAsync();
+            }
+
+            owner?.Dispose();
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    private static async Task WaitForFileOrProcessExit(Process process, string path, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (!File.Exists(path) && !process.HasExited && DateTime.UtcNow < deadline)
+            await Task.Delay(20);
+
+        if (File.Exists(path))
+            return;
+
+        var standardOutput = await process.StandardOutput.ReadToEndAsync();
+        var standardError = await process.StandardError.ReadToEndAsync();
+        throw new InvalidOperationException(
+            $"Cross-process lease host did not become ready. ExitCode={(process.HasExited ? process.ExitCode : -1)}; stdout={standardOutput}; stderr={standardError}");
     }
 
     [Theory]

--- a/Extend0/Lifecycle/CrossProcess/CrossProcessFileLease.cs
+++ b/Extend0/Lifecycle/CrossProcess/CrossProcessFileLease.cs
@@ -15,7 +15,7 @@ internal sealed class CrossProcessFileLease : IDisposable
     private readonly bool _usesRegionLock;
     private FileStream? _stream;
 
-    private CrossProcessFileLease(string name, FileStream stream, bool usesRegionLock)
+    public CrossProcessFileLease(string name, FileStream stream, bool usesRegionLock)
     {
         _name = name;
         _stream = stream;
@@ -72,7 +72,10 @@ internal sealed class CrossProcessFileLease : IDisposable
             if (_usesRegionLock)
             {
                 try { stream.Unlock(0, 1); }
-                catch (IOException) { }
+                catch (IOException)
+                {
+                    // Unlock is best-effort during teardown; disposing the stream releases the OS lock.
+                }
             }
         }
         finally

--- a/Extend0/Lifecycle/CrossProcess/CrossProcessFileLease.cs
+++ b/Extend0/Lifecycle/CrossProcess/CrossProcessFileLease.cs
@@ -1,0 +1,84 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Extend0.Lifecycle.CrossProcess;
+
+/// <summary>
+/// Thread-independent cross-process ownership lease used on Unix platforms.
+/// </summary>
+internal sealed class CrossProcessFileLease : IDisposable
+{
+    private static readonly ConcurrentDictionary<string, byte> OwnedNames = new(StringComparer.Ordinal);
+
+    private readonly string _name;
+    private readonly bool _usesRegionLock;
+    private FileStream? _stream;
+
+    private CrossProcessFileLease(string name, FileStream stream, bool usesRegionLock)
+    {
+        _name = name;
+        _stream = stream;
+        _usesRegionLock = usesRegionLock;
+    }
+
+    internal static bool TryAcquire(string name, out CrossProcessFileLease? lease)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        lease = null;
+
+        if (!OwnedNames.TryAdd(name, 0))
+            return false;
+
+        FileStream? stream = null;
+        try
+        {
+            var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(name))).ToLowerInvariant();
+            var path = Path.Combine(Path.GetTempPath(), $"extend0-cps-{hash[..32]}.lock");
+            var usesRegionLock = OperatingSystem.IsLinux();
+            stream = new FileStream(
+                path,
+                FileMode.OpenOrCreate,
+                FileAccess.ReadWrite,
+                usesRegionLock ? FileShare.ReadWrite | FileShare.Delete : FileShare.None);
+            if (usesRegionLock)
+                stream.Lock(0, 1);
+
+            lease = new CrossProcessFileLease(name, stream, usesRegionLock);
+            return true;
+        }
+        catch (IOException)
+        {
+            stream?.Dispose();
+            OwnedNames.TryRemove(name, out _);
+            return false;
+        }
+        catch
+        {
+            stream?.Dispose();
+            OwnedNames.TryRemove(name, out _);
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        var stream = Interlocked.Exchange(ref _stream, null);
+        if (stream is null)
+            return;
+
+        try
+        {
+            if (_usesRegionLock)
+            {
+                try { stream.Unlock(0, 1); }
+                catch (IOException) { }
+            }
+        }
+        finally
+        {
+            stream.Dispose();
+            OwnedNames.TryRemove(_name, out _);
+        }
+    }
+}

--- a/Extend0/Lifecycle/CrossProcess/CrossProcessHandle.cs
+++ b/Extend0/Lifecycle/CrossProcess/CrossProcessHandle.cs
@@ -259,7 +259,11 @@
             }
             catch
             {
-                try { _ownershipLease?.Dispose(); } catch { }
+                try { _ownershipLease?.Dispose(); }
+                catch
+                {
+                    // Teardown is best-effort and the handle is already marked as disposed.
+                }
             }
         }
 

--- a/Extend0/Lifecycle/CrossProcess/CrossProcessHandle.cs
+++ b/Extend0/Lifecycle/CrossProcess/CrossProcessHandle.cs
@@ -11,12 +11,12 @@
     /// <remarks>
     /// <para>
     /// The handle encapsulates the resources needed to host or access a cross-process singleton:
-    /// the service instance/proxy, an optional named-pipe server (owner only), a process-wide
-    /// mutex (owner only), and a client transport (non-owner only).
+        /// the service instance/proxy, an optional named-pipe server (owner only), a cross-process
+        /// ownership lease (owner only), and a client transport (non-owner only).
     /// </para>
     /// <para>
     /// Disposing the handle tears down these resources in a safe order:
-    /// client transport → cancel hosting token → dispose server → release mutex → dispose service (owner only).
+        /// client transport → cancel hosting token → dispose server → release ownership lease → dispose service (owner only).
     /// Both <see cref="Dispose"/> and <see cref="DisposeAsync"/> are idempotent.
     /// </para>
     /// </remarks>
@@ -42,7 +42,7 @@
         /// </summary>
         public bool IsOwner { get; }
 
-        private readonly Mutex? _mutex;
+        private readonly IDisposable? _ownershipLease;
         private readonly CancellationTokenSource? _cts;
         private readonly ICrossProcessServerHost? _server;
         private readonly IClientTransport? _transport;
@@ -55,18 +55,18 @@
         /// The service instance to expose. For owners, the real implementation; for non-owners, the proxy.
         /// </param>
         /// <param name="isOwner">Whether this handle represents the hosting (owner) side.</param>
-        /// <param name="mutex">The process-wide mutex used to establish ownership (owner only).</param>
+        /// <param name="mutex">The mutex or file lease used to establish ownership (owner only).</param>
         /// <param name="cts">Cancellation token source used to stop the server loop (owner only).</param>
         /// <param name="server">The owner-side server host responsible for exposing the service (owner only).</param>
         /// <param name="transport">The client transport used by the proxy (non-owner only).</param>
         /// <exception cref="ArgumentNullException"><paramref name="service"/> is <c>null</c>.</exception>
         internal CrossProcessHandle(
-            TService service, bool isOwner, Mutex? mutex, CancellationTokenSource? cts,
+            TService service, bool isOwner, IDisposable? mutex, CancellationTokenSource? cts,
             ICrossProcessServerHost? server, IClientTransport? transport)
         {
             Service    = service ?? throw new ArgumentNullException(nameof(service));
             IsOwner    = isOwner;
-            _mutex     = mutex;
+            _ownershipLease = mutex;
             _cts       = cts;
             _server    = server;
             _transport = transport;
@@ -93,8 +93,7 @@
 
             DisposeServerSync();
 
-            ReleaseMutexSafe();
-            DisposeMutexSafe();
+            DisposeOwnershipLeaseSafe();
 
             DisposeServiceSync();
         }
@@ -169,8 +168,7 @@
 
             await DisposeServerAsync().ConfigureAwait(false);
 
-            ReleaseMutexSafe();
-            DisposeMutexSafe();
+            DisposeOwnershipLeaseSafe();
 
             await DisposeServiceAsync().ConfigureAwait(false);
         }
@@ -250,34 +248,18 @@
         /// Any exception (for example, releasing a mutex not owned by the current thread)
         /// is swallowed because it is non-fatal once the handle is being disposed.
         /// </remarks>
-        private void ReleaseMutexSafe()
+        private void DisposeOwnershipLeaseSafe()
         {
             try
             {
-                _mutex?.ReleaseMutex();
-            }
-            catch
-            {
-                // Mutex state issues during shutdown are non-fatal for the process.
-            }
-        }
+                if (_ownershipLease is Mutex mutex)
+                    mutex.ReleaseMutex();
 
-        /// <summary>
-        /// Safely disposes the underlying mutex instance, if any.
-        /// </summary>
-        /// <remarks>
-        /// Disposing the OS handle for the mutex is the final cleanup step.
-        /// Failures are ignored because they are not actionable at this stage.
-        /// </remarks>
-        private void DisposeMutexSafe()
-        {
-            try
-            {
-                _mutex?.Dispose();
+                _ownershipLease?.Dispose();
             }
             catch
             {
-                // Non-actionable failure when releasing OS handle during teardown.
+                try { _ownershipLease?.Dispose(); } catch { }
             }
         }
 

--- a/Extend0/Lifecycle/CrossProcess/CrossProcessOrchestrator.cs
+++ b/Extend0/Lifecycle/CrossProcess/CrossProcessOrchestrator.cs
@@ -101,10 +101,26 @@ namespace Extend0.Lifecycle.CrossProcess
                 endpointName,
                 allowLogicalFallback: clientTransportFactory is not null || serverTransportFactory is not null);
 
-            var m = CrossProcessUtils.CreateOwned(baseName, preferGlobalMutex, out bool createdNew, out bool isGlobal);
+            IDisposable? ownershipLease;
+            bool createdNew;
+            bool isGlobal;
+            string coordinationKind;
 
-            if (createdNew) return HostBranch(factory, baseName, resolvedEndpointName, serverName, resolvedProtocolDescriptor, transportKind, m, isGlobal, authentication, tls, serverTransportFactory);
-            else return ClientBranch(serverName, connectTimeoutMs, resolvedEndpointName, resolvedProtocolDescriptor, transportKind, m, authentication, tls, clientTransportFactory);
+            if (OperatingSystem.IsWindows())
+            {
+                ownershipLease = CrossProcessUtils.CreateOwned(baseName, preferGlobalMutex, out createdNew, out isGlobal);
+                coordinationKind = "OSMutex";
+            }
+            else
+            {
+                createdNew = CrossProcessFileLease.TryAcquire(baseName, out var fileLease);
+                ownershipLease = fileLease;
+                isGlobal = false;
+                coordinationKind = "OSFileLease";
+            }
+
+            if (createdNew) return HostBranch(factory, baseName, resolvedEndpointName, serverName, resolvedProtocolDescriptor, transportKind, ownershipLease!, isGlobal, coordinationKind, authentication, tls, serverTransportFactory);
+            else return ClientBranch(serverName, connectTimeoutMs, resolvedEndpointName, resolvedProtocolDescriptor, transportKind, ownershipLease, authentication, tls, clientTransportFactory);
         }
 
         /// <summary>
@@ -116,12 +132,12 @@ namespace Extend0.Lifecycle.CrossProcess
             string endpointName,
             CrossProcessProtocolDescriptor protocolDescriptor,
             TransportKind transportKind,
-            Mutex m,
+            IDisposable? ownershipLease,
             CrossProcessAuthenticationOptions? authentication,
             CrossProcessTlsOptions? tls,
             Func<ClientTransportFactoryContext, IClientTransport>? clientTransportFactory)
         {
-            try { m.Dispose(); } catch { }
+            try { ownershipLease?.Dispose(); } catch { }
 
             var transport = CrossProcessTransportFactory.CreateClientTransport(
                 new ClientTransportFactoryContext(transportKind, protocolDescriptor, endpointName, serverName, connectTimeoutMs, authentication, tls),
@@ -152,8 +168,9 @@ namespace Extend0.Lifecycle.CrossProcess
             string serverName,
             CrossProcessProtocolDescriptor protocolDescriptor,
             TransportKind transportKind,
-            Mutex m,
+            IDisposable ownershipLease,
             bool isGlobal,
+            string coordinationKind,
             CrossProcessAuthenticationOptions? authentication,
             CrossProcessTlsOptions? tls,
             Func<ServerTransportFactoryContext, ICrossProcessServerHost>? serverTransportFactory)
@@ -169,7 +186,7 @@ namespace Extend0.Lifecycle.CrossProcess
                     serviceBase.ConfigureRuntimeEndpoint(endpointName, serverName, transportKind);
                     serviceBase.ConfigureRuntimeLease(
                         ownershipName,
-                        "OSMutex",
+                        coordinationKind,
                         ownershipName,
                         ResolveCoordinationScope(isGlobal));
                 }
@@ -181,14 +198,14 @@ namespace Extend0.Lifecycle.CrossProcess
                 return new CrossProcessHandle<TService>(
                     impl,
                     isOwner: true,
-                    mutex: m,
+                    mutex: ownershipLease,
                     cts: cts,
                     server: server,
                     transport: null);
             }
             catch
             {
-                TryDisposeState(m, cts, server, impl);
+                TryDisposeState(ownershipLease, cts, server, impl);
                 throw;
             }
         }
@@ -201,14 +218,22 @@ namespace Extend0.Lifecycle.CrossProcess
         /// <summary>
         /// Best-effort cleanup for partially initialized owner state after a hosting failure.
         /// </summary>
-        private static void TryDisposeState(Mutex m, CancellationTokenSource? cts, ICrossProcessServerHost? server, TService? service)
+        private static void TryDisposeState(IDisposable ownershipLease, CancellationTokenSource? cts, ICrossProcessServerHost? server, TService? service)
         {
             try { cts?.Cancel(); } catch { }
             try { server?.Dispose(); } catch { }
             TryDisposeService(service);
             try { cts?.Dispose(); } catch { }
-            try { m.ReleaseMutex(); } catch { }
-            try { m.Dispose(); } catch { }
+            try
+            {
+                if (ownershipLease is Mutex mutex)
+                    mutex.ReleaseMutex();
+                ownershipLease.Dispose();
+            }
+            catch
+            {
+                try { ownershipLease.Dispose(); } catch { }
+            }
         }
 
         /// <summary>

--- a/Extend0/Lifecycle/CrossProcess/CrossProcessOrchestrator.cs
+++ b/Extend0/Lifecycle/CrossProcess/CrossProcessOrchestrator.cs
@@ -137,7 +137,11 @@ namespace Extend0.Lifecycle.CrossProcess
             CrossProcessTlsOptions? tls,
             Func<ClientTransportFactoryContext, IClientTransport>? clientTransportFactory)
         {
-            try { ownershipLease?.Dispose(); } catch { }
+            try { ownershipLease?.Dispose(); }
+            catch
+            {
+                // A losing ownership probe may already have released its resources.
+            }
 
             var transport = CrossProcessTransportFactory.CreateClientTransport(
                 new ClientTransportFactoryContext(transportKind, protocolDescriptor, endpointName, serverName, connectTimeoutMs, authentication, tls),
@@ -232,7 +236,11 @@ namespace Extend0.Lifecycle.CrossProcess
             }
             catch
             {
-                try { ownershipLease.Dispose(); } catch { }
+                try { ownershipLease.Dispose(); }
+                catch
+                {
+                    // Failure-path cleanup is best-effort; preserve the original hosting exception.
+                }
             }
         }
 

--- a/Extend0/Lifecycle/CrossProcess/CrossProcessTransportFactory.cs
+++ b/Extend0/Lifecycle/CrossProcess/CrossProcessTransportFactory.cs
@@ -53,7 +53,8 @@ namespace Extend0.Lifecycle.CrossProcess
         /// <param name="baseName">Logical cross-process service identity.</param>
         /// <param name="transportKind">Transport kind that will back the endpoint.</param>
         /// <param name="explicitEndpointName">
-        /// Optional endpoint override supplied by the caller. When provided, it is returned as-is.
+        /// Optional endpoint override supplied by the caller. Named-pipe overrides are converted to
+        /// the same fixed-size physical name as derived pipe endpoints; other transports use the value as-is.
         /// </param>
         /// <param name="allowLogicalFallback">
         /// When <see langword="true"/>, unsupported built-in kinds fall back to the logical base name so custom
@@ -66,7 +67,9 @@ namespace Extend0.Lifecycle.CrossProcess
             bool allowLogicalFallback = false)
         {
             if (!string.IsNullOrWhiteSpace(explicitEndpointName))
-                return explicitEndpointName;
+                return transportKind == TransportKind.NamedPipe
+                    ? CrossProcessUtils.BuildPipeName(explicitEndpointName)
+                    : explicitEndpointName;
 
             return transportKind switch
             {

--- a/Extend0/Lifecycle/CrossProcess/CrossProcessTransportFactory.cs
+++ b/Extend0/Lifecycle/CrossProcess/CrossProcessTransportFactory.cs
@@ -68,7 +68,7 @@ namespace Extend0.Lifecycle.CrossProcess
         {
             if (!string.IsNullOrWhiteSpace(explicitEndpointName))
                 return transportKind == TransportKind.NamedPipe
-                    ? CrossProcessUtils.BuildPipeName(explicitEndpointName)
+                    ? CrossProcessUtils.NormalizePipeName(explicitEndpointName)
                     : explicitEndpointName;
 
             return transportKind switch

--- a/Extend0/Lifecycle/CrossProcess/CrossProcessUtils.cs
+++ b/Extend0/Lifecycle/CrossProcess/CrossProcessUtils.cs
@@ -216,4 +216,15 @@ internal static class CrossProcessUtils
         return $"{prefix ?? string.Empty}{hash[..32]}";
     }
 
+    /// <summary>
+    /// Preserves already-safe physical pipe names and hashes longer logical names.
+    /// </summary>
+    internal static string NormalizePipeName(string pipeName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pipeName);
+        return Encoding.UTF8.GetByteCount(pipeName) <= 36
+            ? pipeName
+            : BuildPipeName(pipeName);
+    }
+
 }

--- a/Extend0/Lifecycle/CrossProcess/CrossProcessUtils.cs
+++ b/Extend0/Lifecycle/CrossProcess/CrossProcessUtils.cs
@@ -186,7 +186,7 @@ internal static class CrossProcessUtils
     /// Builds a cross-platform, named-pipe-safe endpoint name from an arbitrary base name.
     /// </summary>
     /// <param name="baseName">
-    /// The arbitrary identifier to encode into the pipe name (converted from UTF-8 bytes).
+    /// The arbitrary identifier to hash into the pipe name (converted from UTF-8 bytes).
     /// </param>
     /// <param name="prefix">
     /// Optional prefix to prepend (e.g., <c>"CPS."</c>). If <c>null</c>, nothing is prepended.
@@ -198,34 +198,22 @@ internal static class CrossProcessUtils
     /// </returns>
     /// <remarks>
     /// <para>
-    /// The method encodes <paramref name="baseName"/> as Base64URL (trims trailing <c>'='</c>,
-    /// replaces <c>'+'</c> with <c>'-'</c> and <c>'/'</c> with <c>'_'</c>).
-    /// </para>
-    /// <para>
-    /// To keep names short, if the encoded value exceeds a conservative maximum (<c>220</c> characters),
-    /// the result is truncated to the first <c>100</c> characters and a dot plus a 16-hex
-    /// SHA-256 suffix is appended. This preserves determinism while reducing collision risk and
-    /// staying well within typical OS limits for pipe names.
+    /// Pipe names are represented by a SHA-256 digest. On Unix, .NET implements named pipes with
+    /// Unix-domain sockets and prepends a platform-specific temporary-directory path. A compact,
+    /// fixed-size name is therefore required to remain below Linux and macOS socket-path limits.
     /// </para>
     /// </remarks>
     /// <example>
     /// <code>
-    /// var pipeName = BuildPipeName("CPS:MyService:abc123"); // e.g., "CPS.LUNTOX..._..."
+    /// var pipeName = BuildPipeName("CPS:MyService:abc123"); // e.g., "CPS.5dbf..."
     /// </code>
     /// </example>
     public static string BuildPipeName(string baseName, string? prefix = "CPS.")
     {
         ArgumentNullException.ThrowIfNull(baseName);
 
-        // Base64URL encode (no '+', '/', or '=')
-        var b64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(baseName))
-                  .TrimEnd('=').Replace('+', '-').Replace('/', '_');
-
-        // Keep it short; fall back to a hashed suffix if too long
-        const int max = 220; // headroom for prefixes
-        if (b64.Length <= max) return (prefix ?? string.Empty) + b64;
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(baseName))).ToLowerInvariant();
-        return $"{prefix ?? string.Empty}{b64[..100]}.{hash[..16]}";
+        return $"{prefix ?? string.Empty}{hash[..32]}";
     }
 
 }

--- a/Extend0/Metadata/Internal/MetaDBManager.cs
+++ b/Extend0/Metadata/Internal/MetaDBManager.cs
@@ -295,7 +295,12 @@ namespace Extend0.Metadata
         /// defaults to <c>{AppContext.BaseDirectory}\metadb.deletes.log</c>.
         /// Ignored when running in browser (<see cref="OperatingSystem.IsBrowser"/>).
         /// </param>
-        public MetaDBManager(ILogger? logger, Func<TableSpec?, IMetadataTable>? factory = null, CapacityPolicy capacityPolicy = CapacityPolicy.Throw, string? deleteQueuePath = null)
+        public MetaDBManager(
+            ILogger? logger,
+            Func<TableSpec?, IMetadataTable>? factory = null,
+            CapacityPolicy capacityPolicy = CapacityPolicy.Throw,
+            string? deleteQueuePath = null,
+            bool startDeleteWorker = true)
         {
             _log = logger;
             _isLogActivated = _log != null && _log.IsEnabled(LogLevel.Debug);
@@ -307,7 +312,9 @@ namespace Extend0.Metadata
             {
                 _deleteQueuePath = deleteQueuePath ?? Path.Combine(AppContext.BaseDirectory, DELETES_FILE_DEFAULT_NAME);
                 LoadDeleteQueueFromDisk();
-                _deleteWorkerTask = Task.Run(() => DeleteWorkerLoopAsync(_deleteCts.Token));
+                _deleteWorkerTask = startDeleteWorker
+                    ? Task.Run(() => DeleteWorkerLoopAsync(_deleteCts.Token))
+                    : Task.CompletedTask;
             }
             else
             {

--- a/Extend0/Metadata/Internal/MetaDBManagerHelpers.cs
+++ b/Extend0/Metadata/Internal/MetaDBManagerHelpers.cs
@@ -924,7 +924,7 @@ namespace Extend0.Metadata.Internal
         {
             for (int i = 0; i < attempts - 1; i++)
             {
-                try { DeleteFileOrDirectory(path); return true; }
+                try { DeleteWithStorageLease(path); return true; }
                 catch (FileNotFoundException) { return true; }
                 catch (DirectoryNotFoundException) { return true; }
                 catch (IOException) { await Task.Delay(10 * (i + 1)); }
@@ -932,10 +932,19 @@ namespace Extend0.Metadata.Internal
             }
 
             // Last try
-            try { DeleteFileOrDirectory(path); return true; }
+            try { DeleteWithStorageLease(path); return true; }
             catch (FileNotFoundException) { return true; }
             catch (DirectoryNotFoundException) { return true; }
             catch { return !File.Exists(path) && !Directory.Exists(path); }
+        }
+
+        private static void DeleteWithStorageLease(string path)
+        {
+            if (!MetadataStorageLease.TryAcquire(path, out var lease))
+                throw new IOException($"The metadata storage lease for '{Path.GetFullPath(path)}' is held by another owner.");
+
+            using (lease)
+                DeleteFileOrDirectory(path);
         }
 
         private static void DeleteFileOrDirectory(string path)
@@ -967,13 +976,19 @@ namespace Extend0.Metadata.Internal
         /// </remarks>
         internal static string? TryMoveAside(string path)
         {
-            var isDirectory = Directory.Exists(path);
-            if (!isDirectory && !File.Exists(path)) return null;
+            if (!MetadataStorageLease.TryAcquire(path, out var lease))
+                throw new IOException($"The metadata storage lease for '{Path.GetFullPath(path)}' is held by another owner.");
 
-            var moved = path + ".deleting." + Guid.NewGuid().ToString("N");
-            if (isDirectory) Directory.Move(path, moved);
-            else File.Move(path, moved);
-            return moved;
+            using (lease)
+            {
+                var isDirectory = Directory.Exists(path);
+                if (!isDirectory && !File.Exists(path)) return null;
+
+                var moved = path + ".deleting." + Guid.NewGuid().ToString("N");
+                if (isDirectory) Directory.Move(path, moved);
+                else File.Move(path, moved);
+                return moved;
+            }
         }
 
         /// <summary>

--- a/Extend0/Metadata/Internal/MetadataTable.cs
+++ b/Extend0/Metadata/Internal/MetadataTable.cs
@@ -266,9 +266,7 @@ namespace Extend0.Metadata.Internal
         {
             // The current table owns this lease, so reopening it without closing is rejected
             // consistently on every supported operating system.
-            using (MetadataStorageLease.Acquire(_spec.MapPath))
-            {
-            }
+            MetadataStorageLease.Acquire(_spec.MapPath).Dispose();
 
             var storage = _spec.Storage.Normalize();
             var loaded = storage.Layout == TableStorageLayout.Chunked

--- a/Extend0/Metadata/Internal/MetadataTable.cs
+++ b/Extend0/Metadata/Internal/MetadataTable.cs
@@ -223,6 +223,11 @@ namespace Extend0.Metadata.Internal
         /// </exception>
         public static IMetadataTable Open(TableSpec spec)
         {
+            // Fail with the domain-specific ownership error before platform-specific mapping APIs do.
+            using (MetadataStorageLease.Acquire(spec.MapPath))
+            {
+            }
+
             var storage = spec.Storage.Normalize();
             var loaded = storage.Layout == TableStorageLayout.Chunked
                 ? SegmentedMappedStore.TryLoadColumns(spec.MapPath, out var columns)
@@ -261,6 +266,12 @@ namespace Extend0.Metadata.Internal
         /// </exception>
         public IMetadataTable Open()
         {
+            // The current table owns this lease, so reopening it without closing is rejected
+            // consistently on every supported operating system.
+            using (MetadataStorageLease.Acquire(_spec.MapPath))
+            {
+            }
+
             var storage = _spec.Storage.Normalize();
             var loaded = storage.Layout == TableStorageLayout.Chunked
                 ? SegmentedMappedStore.TryLoadColumns(_spec.MapPath, out var columns)

--- a/Extend0/Metadata/Internal/MetadataTable.cs
+++ b/Extend0/Metadata/Internal/MetadataTable.cs
@@ -224,9 +224,7 @@ namespace Extend0.Metadata.Internal
         public static IMetadataTable Open(TableSpec spec)
         {
             // Fail with the domain-specific ownership error before platform-specific mapping APIs do.
-            using (MetadataStorageLease.Acquire(spec.MapPath))
-            {
-            }
+            MetadataStorageLease.Acquire(spec.MapPath).Dispose();
 
             var storage = spec.Storage.Normalize();
             var loaded = storage.Layout == TableStorageLayout.Chunked

--- a/Extend0/Metadata/Storage/Internal/MappedStore.cs
+++ b/Extend0/Metadata/Storage/Internal/MappedStore.cs
@@ -50,6 +50,7 @@ namespace Extend0.Metadata.Storage.Internal
         private FileHeader* _hdr;
         private ColumnDesc* _cols;
         private readonly string _path;     // Path to the mapped file
+        private readonly MetadataStorageLease _storageLease;
         private long _length;              // Current file length
         private readonly int _chunkSize;
         private readonly int _slabAlignment;
@@ -189,28 +190,38 @@ namespace Extend0.Metadata.Storage.Internal
 
             var fullPath = Path.GetFullPath(spec.MapPath);
             _path = fullPath;
+            _storageLease = MetadataStorageLease.Acquire(fullPath);
 
-            using var mutationLock = AcquireMapMutationLock(fullPath);
-
-            var dir = Path.GetDirectoryName(fullPath)!;
-            Directory.CreateDirectory(dir);
-            spec.SaveToDirectory(dir);
-
-            ThrowParsed(() =>
+            try
             {
-                using (var fs = new FileStream(fullPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read))
+                using var mutationLock = AcquireMapMutationLock(fullPath);
+
+                var dir = Path.GetDirectoryName(fullPath)!;
+                Directory.CreateDirectory(dir);
+                spec.SaveToDirectory(dir);
+
+                ThrowParsed(() =>
                 {
-                    if (fs.Length < fileSize) fs.SetLength(fileSize);
-                    _length = fs.Length;
-                }
-            });
+                    using (var fs = new FileStream(fullPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read))
+                    {
+                        if (fs.Length < fileSize) fs.SetLength(fileSize);
+                        _length = fs.Length;
+                    }
+                });
 
-            OpenMapping();
+                ThrowParsed(OpenMapping);
 
-            // Initialize header and column descriptors if the file is new / uninitialized
-            InitializeMappedFile(columns, batch);
+                // Initialize header and column descriptors if the file is new / uninitialized
+                InitializeMappedFile(columns, batch);
 
-            if (rented is not null) ArrayPool<ColumnDesc>.Shared.Return(rented, clearArray: true);
+                if (rented is not null) ArrayPool<ColumnDesc>.Shared.Return(rented, clearArray: true);
+            }
+            catch
+            {
+                _storageLease.Dispose();
+                if (rented is not null) ArrayPool<ColumnDesc>.Shared.Return(rented, clearArray: true);
+                throw;
+            }
         }
 
         /// <summary>
@@ -712,8 +723,15 @@ namespace Extend0.Metadata.Storage.Internal
         public void Dispose()
         {
             if (_disposed) return;
-            CloseMapping(flush: true);
-            _disposed = true;
+            try
+            {
+                CloseMapping(flush: true);
+            }
+            finally
+            {
+                _storageLease.Dispose();
+                _disposed = true;
+            }
         }
 
         /// <inheritdoc/>

--- a/Extend0/Metadata/Storage/Internal/MetadataStorageLease.cs
+++ b/Extend0/Metadata/Storage/Internal/MetadataStorageLease.cs
@@ -1,0 +1,119 @@
+using Extend0.Metadata.Diagnostics;
+using System.Collections.Concurrent;
+
+namespace Extend0.Metadata.Storage.Internal;
+
+/// <summary>
+/// Holds the cooperative, cross-process writer lease for a persistent metadata table.
+/// </summary>
+/// <remarks>
+/// <para>
+/// File sharing flags are not a portable ownership primitive: Unix permits unlinking an open
+/// mapped file and does not consistently enforce <see cref="FileShare.None"/>. Extend0 therefore
+/// coordinates through a stable sidecar file and an OS byte-range lock.
+/// </para>
+/// <para>
+/// The in-process registry complements the OS lock because some Unix lock implementations treat
+/// locks as process-scoped. The sidecar is intentionally retained after release so deletion and a
+/// concurrent opener always coordinate on the same inode.
+/// </para>
+/// </remarks>
+internal sealed class MetadataStorageLease : IDisposable
+{
+    private static readonly ConcurrentDictionary<string, byte> OwnedPaths = new(GetPathComparer());
+
+    private readonly string _key;
+    private FileStream? _stream;
+
+    private MetadataStorageLease(string key, FileStream stream)
+    {
+        _key = key;
+        _stream = stream;
+    }
+
+    internal static MetadataStorageLease Acquire(string tablePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tablePath);
+
+        var fullPath = Path.GetFullPath(tablePath);
+        var key = NormalizeKey(fullPath);
+        if (!OwnedPaths.TryAdd(key, 0))
+        {
+            throw new MetadataTableLockedException(
+                $"Metadata table is already open in this process. Path='{fullPath}'.",
+                new IOException("The cooperative metadata storage lease is already owned."));
+        }
+
+        FileStream? stream = null;
+        try
+        {
+            var leasePath = GetLeasePath(fullPath);
+            var parent = Path.GetDirectoryName(leasePath);
+            if (!string.IsNullOrWhiteSpace(parent))
+                Directory.CreateDirectory(parent);
+
+            stream = new FileStream(
+                leasePath,
+                FileMode.OpenOrCreate,
+                FileAccess.ReadWrite,
+                FileShare.ReadWrite | FileShare.Delete);
+            stream.Lock(0, 1);
+            return new MetadataStorageLease(key, stream);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            stream?.Dispose();
+            OwnedPaths.TryRemove(key, out _);
+            throw new MetadataTableLockedException(
+                $"Metadata table is locked by another owner. Path='{fullPath}'.",
+                ex);
+        }
+        catch
+        {
+            stream?.Dispose();
+            OwnedPaths.TryRemove(key, out _);
+            throw;
+        }
+    }
+
+    internal static bool TryAcquire(string tablePath, out MetadataStorageLease? lease)
+    {
+        try
+        {
+            lease = Acquire(tablePath);
+            return true;
+        }
+        catch (MetadataTableLockedException)
+        {
+            lease = null;
+            return false;
+        }
+    }
+
+    internal static string GetLeasePath(string tablePath) => Path.GetFullPath(tablePath) + ".extend0.lock";
+
+    public void Dispose()
+    {
+        var stream = Interlocked.Exchange(ref _stream, null);
+        if (stream is null)
+            return;
+
+        try
+        {
+            try { stream.Unlock(0, 1); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+        finally
+        {
+            stream.Dispose();
+            OwnedPaths.TryRemove(_key, out _);
+        }
+    }
+
+    private static string NormalizeKey(string fullPath) =>
+        OperatingSystem.IsWindows() ? fullPath.ToUpperInvariant() : fullPath;
+
+    private static IEqualityComparer<string> GetPathComparer() =>
+        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+}

--- a/Extend0/Metadata/Storage/Internal/MetadataStorageLease.cs
+++ b/Extend0/Metadata/Storage/Internal/MetadataStorageLease.cs
@@ -26,7 +26,7 @@ internal sealed class MetadataStorageLease : IDisposable
     private readonly bool _usesRegionLock;
     private FileStream? _stream;
 
-    private MetadataStorageLease(string key, FileStream stream, bool usesRegionLock)
+    public MetadataStorageLease(string key, FileStream stream, bool usesRegionLock)
     {
         _key = key;
         _stream = stream;
@@ -109,8 +109,14 @@ internal sealed class MetadataStorageLease : IDisposable
                 if (_usesRegionLock)
                     stream.Unlock(0, 1);
             }
-            catch (IOException) { }
-            catch (UnauthorizedAccessException) { }
+            catch (IOException)
+            {
+                // Unlock is best-effort during teardown; disposing the stream releases the OS lock.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Unlock is best-effort during teardown; disposing the stream releases the OS lock.
+            }
         }
         finally
         {

--- a/Extend0/Metadata/Storage/Internal/MetadataStorageLease.cs
+++ b/Extend0/Metadata/Storage/Internal/MetadataStorageLease.cs
@@ -10,7 +10,7 @@ namespace Extend0.Metadata.Storage.Internal;
 /// <para>
 /// File sharing flags are not a portable ownership primitive: Unix permits unlinking an open
 /// mapped file and does not consistently enforce <see cref="FileShare.None"/>. Extend0 therefore
-/// coordinates through a stable sidecar file and an OS byte-range lock.
+/// coordinates through a stable sidecar file and an OS-enforced exclusive handle or byte-range lock.
 /// </para>
 /// <para>
 /// The in-process registry complements the OS lock because some Unix lock implementations treat
@@ -23,12 +23,14 @@ internal sealed class MetadataStorageLease : IDisposable
     private static readonly ConcurrentDictionary<string, byte> OwnedPaths = new(GetPathComparer());
 
     private readonly string _key;
+    private readonly bool _usesRegionLock;
     private FileStream? _stream;
 
-    private MetadataStorageLease(string key, FileStream stream)
+    private MetadataStorageLease(string key, FileStream stream, bool usesRegionLock)
     {
         _key = key;
         _stream = stream;
+        _usesRegionLock = usesRegionLock;
     }
 
     internal static MetadataStorageLease Acquire(string tablePath)
@@ -52,13 +54,15 @@ internal sealed class MetadataStorageLease : IDisposable
             if (!string.IsNullOrWhiteSpace(parent))
                 Directory.CreateDirectory(parent);
 
+            var usesRegionLock = OperatingSystem.IsLinux();
             stream = new FileStream(
                 leasePath,
                 FileMode.OpenOrCreate,
                 FileAccess.ReadWrite,
-                FileShare.ReadWrite | FileShare.Delete);
-            stream.Lock(0, 1);
-            return new MetadataStorageLease(key, stream);
+                usesRegionLock ? FileShare.ReadWrite | FileShare.Delete : FileShare.None);
+            if (usesRegionLock)
+                stream.Lock(0, 1);
+            return new MetadataStorageLease(key, stream, usesRegionLock);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
@@ -100,7 +104,11 @@ internal sealed class MetadataStorageLease : IDisposable
 
         try
         {
-            try { stream.Unlock(0, 1); }
+            try
+            {
+                if (_usesRegionLock)
+                    stream.Unlock(0, 1);
+            }
             catch (IOException) { }
             catch (UnauthorizedAccessException) { }
         }

--- a/Extend0/Metadata/Storage/Internal/SegmentedMappedStore.cs
+++ b/Extend0/Metadata/Storage/Internal/SegmentedMappedStore.cs
@@ -30,6 +30,7 @@ namespace Extend0.Metadata.Storage.Internal
         };
 
         private readonly string _directory;
+        private readonly MetadataStorageLease _storageLease;
         private readonly string _chunksDirectory;
         private readonly int _chunkSize;
         private readonly ColumnState[] _columns;
@@ -43,34 +44,43 @@ namespace Extend0.Metadata.Storage.Internal
                 throw new ArgumentException("SegmentedMappedStore requires chunked table storage.", nameof(spec));
 
             _directory = Path.GetFullPath(spec.MapPath);
+            _storageLease = MetadataStorageLease.Acquire(_directory);
             _chunksDirectory = Path.Combine(_directory, ChunksDirectoryName);
             _chunkSize = storage.ChunkSize;
             _colNameUtf8 = new byte[spec.Columns.Length][];
 
-            using var mutationLock = AcquireMutationLock(_directory);
-            Directory.CreateDirectory(_chunksDirectory);
-            spec.SaveToFile(Path.Combine(_directory, SpecFileName));
-
-            var manifestPath = GetManifestPath(_directory);
-            if (File.Exists(manifestPath))
+            try
             {
-                var manifest = LoadManifest(manifestPath);
-                _columns = CreateStatesFromManifest(spec, manifest);
+                using var mutationLock = AcquireMutationLock(_directory);
+                Directory.CreateDirectory(_chunksDirectory);
+                spec.SaveToFile(Path.Combine(_directory, SpecFileName));
+
+                var manifestPath = GetManifestPath(_directory);
+                if (File.Exists(manifestPath))
+                {
+                    var manifest = LoadManifest(manifestPath);
+                    _columns = CreateStatesFromManifest(spec, manifest);
+                }
+                else
+                {
+                    _columns = CreateInitialStates(spec.Columns);
+                    SaveManifest();
+                }
+
+                for (int i = 0; i < _columns.Length; i++)
+                {
+                    var keySize = _columns[i].KeySize;
+                    var max = Math.Max(0, keySize - 1);
+                    var bytes = Encoding.UTF8.GetBytes(spec.Columns[i].Name);
+                    _colNameUtf8[i] = bytes.Length > max ? bytes.AsSpan(0, max).ToArray() : bytes;
+
+                    EnsureChunkCount(_columns[i], GetRequiredChunkCount(_columns[i]));
+                }
             }
-            else
+            catch
             {
-                _columns = CreateInitialStates(spec.Columns);
-                SaveManifest();
-            }
-
-            for (int i = 0; i < _columns.Length; i++)
-            {
-                var keySize = _columns[i].KeySize;
-                var max = Math.Max(0, keySize - 1);
-                var bytes = Encoding.UTF8.GetBytes(spec.Columns[i].Name);
-                _colNameUtf8[i] = bytes.Length > max ? bytes.AsSpan(0, max).ToArray() : bytes;
-
-                EnsureChunkCount(_columns[i], GetRequiredChunkCount(_columns[i]));
+                _storageLease.Dispose();
+                throw;
             }
         }
 
@@ -248,12 +258,17 @@ namespace Extend0.Metadata.Storage.Internal
         public void Dispose()
         {
             if (_disposed) return;
-
-            foreach (var column in _columns)
-                foreach (var chunk in column.Chunks)
-                    chunk.Dispose();
-
-            _disposed = true;
+            try
+            {
+                foreach (var column in _columns)
+                    foreach (var chunk in column.Chunks)
+                        chunk.Dispose();
+            }
+            finally
+            {
+                _storageLease.Dispose();
+                _disposed = true;
+            }
         }
 
         public static bool TryLoadColumns(string path, out ColumnConfiguration[] columns)

--- a/docs/Runtime/MetaDB.md
+++ b/docs/Runtime/MetaDB.md
@@ -54,8 +54,8 @@ That means:
 ## Portable Persistent-Storage Contract
 
 Persistent single-file and chunked tables use one cooperative writer lease per normalized `MapPath`.
-The lease is held for the lifetime of the mapped store and is backed by an OS byte-range lock on the
-stable `<MapPath>.extend0.lock` sidecar. A second owner receives
+The lease is held for the lifetime of the mapped store and is backed by an OS-enforced exclusive
+handle or byte-range lock on the stable `<MapPath>.extend0.lock` sidecar. A second owner receives
 `MetadataTableLockedException` on Windows, Linux, and macOS.
 
 Open, delete, move-aside, and recovery follow these rules:

--- a/docs/Runtime/MetaDB.md
+++ b/docs/Runtime/MetaDB.md
@@ -51,6 +51,26 @@ That means:
 - preserve the conceptual distinction between the `MetaDB` system and the manager that operates it
 - keep demo tables out of the core domain vocabulary unless they become accepted architecture
 
+## Portable Persistent-Storage Contract
+
+Persistent single-file and chunked tables use one cooperative writer lease per normalized `MapPath`.
+The lease is held for the lifetime of the mapped store and is backed by an OS byte-range lock on the
+stable `<MapPath>.extend0.lock` sidecar. A second owner receives
+`MetadataTableLockedException` on Windows, Linux, and macOS.
+
+Open, delete, move-aside, and recovery follow these rules:
+
+- opening an already-owned table fails without replacing or truncating its storage
+- deletion and move-aside must acquire the same lease and otherwise remain queued for retry
+- missing files are a successful idempotent delete
+- a released or abandoned process lease permits a later owner to open or clean up the table
+- sidecar files are retained intentionally so every process continues to coordinate on the same inode
+- the read-only file attribute is not a portable deletion lock; Unix uses directory permissions while Windows may reject deletion or rename
+
+The contract is cooperative. External programs that ignore the sidecar can still rename or unlink an
+open file on Unix. Deployments must keep the table and sidecar together and grant mutation access only
+to actors that follow the Extend0 ownership protocol.
+
 ## Schema Evolution
 
 `TableSpec` is the schema contract for a MetaDB table.


### PR DESCRIPTION
## Summary

- replace platform-dependent mapped-file ownership assumptions with a cooperative sidecar lease backed by an OS-enforced exclusive handle or byte-range lock
- hold the lease for the full lifetime of single-file and chunked mapped stores
- make delete and move-aside paths acquire the same lease before mutating storage
- use thread-independent file leases for Unix singleton ownership while retaining named mutexes on Windows
- use fixed-size hashed named-pipe endpoints so .NET's Unix-domain-socket implementation stays below Linux and macOS path limits
- classify read-only deletion explicitly: Windows attributes may block deletion, while Unix deletion is governed by directory permissions
- remove a delete-worker race from the queue persistence test
- add a clean-process contention test covering open, delete, owner exit, and recovery
- document the portable contract and its cooperative boundary

## Root cause

The existing suite treated Windows file-sharing and deletion behavior as a universal contract. Unix may unlink open mapped files and does not use the read-only file bit as a deletion lock. Thread-affine mutex ownership also became unreliable across async continuations on Unix. Separately, Base64 endpoint names were short enough for Windows pipes but exceeded Unix-domain-socket path limits once .NET prepended its temporary path.

## Validation

GitHub Actions run [#29357088433](https://github.com/Papishushi/Extend0/actions/runs/29357088433) completed successfully:

- Windows: 563 tests, CLI build, and doctor JSON
- Ubuntu: 563 tests, CLI build, and doctor JSON
- macOS: 563 tests, CLI build, and doctor JSON
- package build, identity/version inspection, and artifact upload
- all static-analysis findings reported on the initial diff were addressed

Closes #5