### PR TITLE
Build and validate native ARM64 release artifacts

### DIFF
--- a/.github/workflows/arm64-release.yml
+++ b/.github/workflows/arm64-release.yml
@@ -125,12 +125,18 @@ jobs:
         env:
           EXPECTED_VERSION: ${{ needs.version.outputs.version }}
         run: |
-          dotnet run --project eng/Extend0.ReleaseSmoke/Extend0.ReleaseSmoke.csproj `
+          dotnet build eng/Extend0.ReleaseSmoke/Extend0.ReleaseSmoke.csproj `
+            -c Release `
+            -r ${{ matrix.rid }}
+          if ($LASTEXITCODE -ne 0) { throw 'MetaDB ARM64 release smoke build failed' }
+          $json = & dotnet run --project eng/Extend0.ReleaseSmoke/Extend0.ReleaseSmoke.csproj `
+            --no-build `
             -c Release `
             -r ${{ matrix.rid }} `
-            -- $env:EXPECTED_VERSION | Set-Content -Encoding utf8 metadb-smoke.json
+            -- $env:EXPECTED_VERSION
           if ($LASTEXITCODE -ne 0) { throw 'MetaDB ARM64 release smoke failed' }
-          $smoke = Get-Content metadb-smoke.json -Raw | ConvertFrom-Json
+          $json | Set-Content -Encoding utf8 metadb-smoke.json
+          $smoke = $json | ConvertFrom-Json
           if ($smoke.metadb_ready -ne $true -or $smoke.restart -ne $true -or $smoke.cleanup -ne $true) {
             throw 'MetaDB release smoke did not complete every lifecycle phase'
           }

--- a/.github/workflows/arm64-release.yml
+++ b/.github/workflows/arm64-release.yml
@@ -100,6 +100,11 @@ jobs:
             -p:DebugSymbols=false `
             -o publish
           if ($LASTEXITCODE -ne 0) { throw 'dotnet publish failed' }
+          if ('${{ matrix.rid }}' -eq 'win-arm64') {
+            Move-Item publish/Extend0.Cli.exe publish/extend0.exe
+          } else {
+            Move-Item publish/Extend0.Cli publish/extend0
+          }
       - name: Validate doctor JSON and version
         shell: pwsh
         env:

--- a/.github/workflows/arm64-release.yml
+++ b/.github/workflows/arm64-release.yml
@@ -1,0 +1,256 @@
+name: ARM64 release artifacts
+
+on:
+  pull_request:
+    paths:
+      - "Extend0/**"
+      - "Extend0.Cli/**"
+      - "Extend0.Tests/**"
+      - "eng/Extend0.ReleaseSmoke/**"
+      - "docs/Runtime/ARM64.md"
+      - "global.json"
+      - ".github/workflows/arm64-release.yml"
+  push:
+    branches: [main]
+    tags: ["v*"]
+    paths:
+      - "Extend0/**"
+      - "Extend0.Cli/**"
+      - "eng/Extend0.ReleaseSmoke/**"
+      - "global.json"
+      - ".github/workflows/arm64-release.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: arm64-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - name: Read and validate package version
+        id: version
+        shell: bash
+        run: |
+          version="$(python - <<'PY'
+          import xml.etree.ElementTree as ET
+
+          projects = [
+              "Extend0/Extend0.csproj",
+              "Extend0.Cli/Extend0.Cli.csproj",
+          ]
+          versions = {ET.parse(project).findtext(".//Version") for project in projects}
+          if None in versions or len(versions) != 1:
+              raise SystemExit(f"ARM64 project versions are not aligned: {versions}")
+          print(versions.pop())
+          PY
+          )"
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+          if [[ "$GITHUB_REF_TYPE" == "tag" && "$GITHUB_REF_NAME" != "v$version" ]]; then
+            echo "Tag '$GITHUB_REF_NAME' must equal 'v$version'." >&2
+            exit 1
+          fi
+
+  native-smoke:
+    needs: version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: linux-arm64
+            runner: ubuntu-24.04-arm
+            executable: ./publish/extend0
+            archive: tar.gz
+          - rid: win-arm64
+            runner: windows-11-arm
+            executable: ./publish/extend0.exe
+            archive: zip
+          - rid: osx-arm64
+            runner: macos-15
+            executable: ./publish/extend0
+            archive: tar.gz
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-dotnet@v5.4.0
+        with:
+          global-json-file: global.json
+      - name: Require native ARM64 runner
+        shell: pwsh
+        run: |
+          if ($env:RUNNER_ARCH -ne 'ARM64') {
+            throw "RID ${{ matrix.rid }} requires a native ARM64 runner; RUNNER_ARCH=$env:RUNNER_ARCH"
+          }
+      - name: Publish self-contained CLI
+        shell: pwsh
+        run: |
+          dotnet publish Extend0.Cli/Extend0.Cli.csproj `
+            -c Release `
+            -r ${{ matrix.rid }} `
+            --self-contained true `
+            -p:PublishSingleFile=true `
+            -p:DebugType=None `
+            -p:DebugSymbols=false `
+            -o publish
+          if ($LASTEXITCODE -ne 0) { throw 'dotnet publish failed' }
+      - name: Validate doctor JSON and version
+        shell: pwsh
+        env:
+          EXPECTED_VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          $json = & '${{ matrix.executable }}' doctor --repo $env:GITHUB_WORKSPACE --json
+          if ($LASTEXITCODE -ne 0) { throw 'extend0 doctor failed' }
+          $json | Set-Content -Encoding utf8 doctor.json
+          $report = $json | ConvertFrom-Json
+          if ($report.version -ne $env:EXPECTED_VERSION) {
+            throw "doctor version '$($report.version)' does not match '$env:EXPECTED_VERSION'"
+          }
+          if ($report.metadb_ready -ne $true) { throw 'doctor did not report metadb_ready=true' }
+          if ($report.architecture -ne 'Arm64') { throw "doctor reported architecture '$($report.architecture)'" }
+          if ($report.ErrorCount -ne 0) { throw "doctor reported $($report.ErrorCount) errors" }
+      - name: Exercise MetaDB create, restart, and cleanup
+        shell: pwsh
+        env:
+          EXPECTED_VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          dotnet run --project eng/Extend0.ReleaseSmoke/Extend0.ReleaseSmoke.csproj `
+            -c Release `
+            -r ${{ matrix.rid }} `
+            -- $env:EXPECTED_VERSION | Set-Content -Encoding utf8 metadb-smoke.json
+          if ($LASTEXITCODE -ne 0) { throw 'MetaDB ARM64 release smoke failed' }
+          $smoke = Get-Content metadb-smoke.json -Raw | ConvertFrom-Json
+          if ($smoke.metadb_ready -ne $true -or $smoke.restart -ne $true -or $smoke.cleanup -ne $true) {
+            throw 'MetaDB release smoke did not complete every lifecycle phase'
+          }
+      - name: Stage native archive
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          RID: ${{ matrix.rid }}
+          ARCHIVE: ${{ matrix.archive }}
+        run: |
+          Copy-Item doctor.json publish/doctor.json
+          Copy-Item metadb-smoke.json publish/metadb-smoke.json
+          New-Item -ItemType Directory -Force native | Out-Null
+          $name = "extend0-cli-$env:VERSION-$env:RID"
+          if ($env:ARCHIVE -eq 'zip') {
+            Compress-Archive -Path publish/* -DestinationPath "native/$name.zip"
+          } else {
+            tar -czf "native/$name.tar.gz" -C publish .
+            if ($LASTEXITCODE -ne 0) { throw 'tar failed' }
+          }
+      - uses: actions/upload-artifact@v7.0.1
+        with:
+          name: extend0-arm64-raw-${{ needs.version.outputs.version }}-${{ matrix.rid }}
+          path: native/
+          if-no-files-found: error
+          retention-days: 14
+
+  finalize:
+    needs: [version, native-smoke]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: linux-arm64
+            archive: tar.gz
+          - rid: win-arm64
+            archive: zip
+          - rid: osx-arm64
+            archive: tar.gz
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/download-artifact@v7.0.0
+        with:
+          name: extend0-arm64-raw-${{ needs.version.outputs.version }}-${{ matrix.rid }}
+          path: input
+      - name: Extract smoke-tested payload
+        shell: bash
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          RID: ${{ matrix.rid }}
+          ARCHIVE: ${{ matrix.archive }}
+        run: |
+          mkdir -p payload
+          name="extend0-cli-$VERSION-$RID"
+          if [[ "$ARCHIVE" == "zip" ]]; then
+            unzip -q "input/$name.zip" -d payload
+          else
+            tar -xzf "input/$name.tar.gz" -C payload
+          fi
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: payload
+          format: spdx-json
+          output-file: payload/sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+      - name: Build immutable archive and checksum
+        shell: bash
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          RID: ${{ matrix.rid }}
+          ARCHIVE: ${{ matrix.archive }}
+        run: |
+          mkdir -p dist
+          name="extend0-cli-$VERSION-$RID"
+          cp payload/sbom.spdx.json "dist/$name.spdx.json"
+          if [[ "$ARCHIVE" == "zip" ]]; then
+            (cd payload && zip -qr "../dist/$name.zip" .)
+          else
+            tar -czf "dist/$name.tar.gz" -C payload .
+          fi
+          (cd dist && sha256sum "$name.$ARCHIVE" > "$name.$ARCHIVE.sha256")
+      - name: Attest build provenance
+        if: github.event_name != 'pull_request'
+        uses: actions/attest@v4
+        with:
+          subject-path: dist/extend0-cli-${{ needs.version.outputs.version }}-${{ matrix.rid }}.${{ matrix.archive }}
+      - name: Attest SPDX SBOM
+        if: github.event_name != 'pull_request'
+        uses: actions/attest@v4
+        with:
+          subject-path: dist/extend0-cli-${{ needs.version.outputs.version }}-${{ matrix.rid }}.${{ matrix.archive }}
+          sbom-path: dist/extend0-cli-${{ needs.version.outputs.version }}-${{ matrix.rid }}.spdx.json
+      - uses: actions/upload-artifact@v7.0.1
+        with:
+          name: extend0-arm64-${{ needs.version.outputs.version }}-${{ matrix.rid }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 30
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [version, finalize]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v7.0.0
+        with:
+          pattern: extend0-arm64-${{ needs.version.outputs.version }}-*
+          path: dist
+          merge-multiple: true
+      - name: Publish immutable versioned release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --generate-notes \
+            --title "Extend0 $GITHUB_REF_NAME"

--- a/Extend0.Cli/DoctorCommand.cs
+++ b/Extend0.Cli/DoctorCommand.cs
@@ -1,3 +1,6 @@
+using Extend0.Metadata;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Xml.Linq;
@@ -78,12 +81,43 @@ public static class DoctorCommand
         CheckFile(checks, root, "test-project", Path.Combine("Extend0.Tests", "Extend0.Tests.csproj"), required: false);
         CheckFile(checks, root, "testing-harness-project", Path.Combine("Extend0.Testing", "Extend0.Testing.csproj"), required: false);
 
+        var metaDbReady = CheckMetaDbManager(checks);
         CheckTargetFramework(checks, root);
         CheckCliToolConfiguration(checks, root);
         CheckReadmeTargetFramework(checks, root);
         CheckOntologyAccessSurfaceRange(checks, root);
 
-        return DoctorReport.Create(root, DateTimeOffset.UtcNow, checks);
+        return DoctorReport.Create(
+            GetProductVersion(),
+            RuntimeInformation.RuntimeIdentifier,
+            RuntimeInformation.OSArchitecture.ToString(),
+            metaDbReady,
+            root,
+            DateTimeOffset.UtcNow,
+            checks);
+    }
+
+    private static bool CheckMetaDbManager(List<DoctorCheck> checks)
+    {
+        try
+        {
+            using var manager = MetaDB.CreateManager();
+            checks.Add(DoctorCheck.Pass("metadb-manager", "Constructed the public MetaDB manager."));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            checks.Add(new DoctorCheck("metadb-manager", DoctorStatus.Error, $"Could not construct the public MetaDB manager: {ex.Message}"));
+            return false;
+        }
+    }
+
+    private static string GetProductVersion()
+    {
+        var informationalVersion = typeof(MetaDB).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+        return informationalVersion?.Split('+', 2)[0] ?? "unknown";
     }
 
     private static void CheckFile(List<DoctorCheck> checks, string root, string id, string relativePath, bool required)
@@ -216,6 +250,9 @@ public static class DoctorCommand
     private static void WriteHumanReport(TextWriter output, DoctorReport report)
     {
         output.WriteLine("Extend0 doctor");
+        output.WriteLine($"Version: {report.Version}");
+        output.WriteLine($"Runtime: {report.RuntimeIdentifier} ({report.Architecture})");
+        output.WriteLine($"MetaDB ready: {report.MetaDbReady}");
         output.WriteLine($"Root: {report.RepositoryRoot}");
         output.WriteLine();
 

--- a/Extend0.Cli/DoctorReport.cs
+++ b/Extend0.Cli/DoctorReport.cs
@@ -1,6 +1,13 @@
+using System.Text.Json.Serialization;
+using System.Runtime.InteropServices;
+
 namespace Extend0.Cli;
 
 public sealed record DoctorReport(
+    [property: JsonPropertyName("version")] string Version,
+    [property: JsonPropertyName("runtime_identifier")] string RuntimeIdentifier,
+    [property: JsonPropertyName("architecture")] string Architecture,
+    [property: JsonPropertyName("metadb_ready")] bool MetaDbReady,
     string RepositoryRoot,
     DateTimeOffset GeneratedAtUtc,
     IReadOnlyList<DoctorCheck> Checks,
@@ -8,16 +15,74 @@ public sealed record DoctorReport(
     int WarningCount,
     int ErrorCount)
 {
-    public static DoctorReport Create(string repositoryRoot, DateTimeOffset generatedAtUtc, IReadOnlyList<DoctorCheck> checks)
+    public DoctorReport(
+        string repositoryRoot,
+        DateTimeOffset generatedAtUtc,
+        IReadOnlyList<DoctorCheck> checks,
+        int passCount,
+        int warningCount,
+        int errorCount)
+        : this(
+            "unknown",
+            RuntimeInformation.RuntimeIdentifier,
+            RuntimeInformation.OSArchitecture.ToString(),
+            false,
+            repositoryRoot,
+            generatedAtUtc,
+            checks,
+            passCount,
+            warningCount,
+            errorCount)
+    {
+    }
+
+    public static DoctorReport Create(string repositoryRoot, DateTimeOffset generatedAtUtc, IReadOnlyList<DoctorCheck> checks) =>
+        Create(
+            "unknown",
+            RuntimeInformation.RuntimeIdentifier,
+            RuntimeInformation.OSArchitecture.ToString(),
+            false,
+            repositoryRoot,
+            generatedAtUtc,
+            checks);
+
+    public static DoctorReport Create(
+        string version,
+        string runtimeIdentifier,
+        string architecture,
+        bool metaDbReady,
+        string repositoryRoot,
+        DateTimeOffset generatedAtUtc,
+        IReadOnlyList<DoctorCheck> checks)
     {
         ArgumentNullException.ThrowIfNull(checks);
 
         return new DoctorReport(
+            version,
+            runtimeIdentifier,
+            architecture,
+            metaDbReady,
             repositoryRoot,
             generatedAtUtc,
             checks,
             checks.Count(static c => c.Status == DoctorStatus.Pass),
             checks.Count(static c => c.Status == DoctorStatus.Warning),
             checks.Count(static c => c.Status == DoctorStatus.Error));
+    }
+
+    public void Deconstruct(
+        out string repositoryRoot,
+        out DateTimeOffset generatedAtUtc,
+        out IReadOnlyList<DoctorCheck> checks,
+        out int passCount,
+        out int warningCount,
+        out int errorCount)
+    {
+        repositoryRoot = RepositoryRoot;
+        generatedAtUtc = GeneratedAtUtc;
+        checks = Checks;
+        passCount = PassCount;
+        warningCount = WarningCount;
+        errorCount = ErrorCount;
     }
 }

--- a/Extend0.Tests/Cli/Extend0CliTests.cs
+++ b/Extend0.Tests/Cli/Extend0CliTests.cs
@@ -691,6 +691,10 @@ public sealed class Extend0CliTests
 
             using var document = JsonDocument.Parse(output.ToString());
             Assert.Equal(0, exitCode);
+            Assert.Equal("1.0.9535", document.RootElement.GetProperty("version").GetString());
+            Assert.False(string.IsNullOrWhiteSpace(document.RootElement.GetProperty("runtime_identifier").GetString()));
+            Assert.False(string.IsNullOrWhiteSpace(document.RootElement.GetProperty("architecture").GetString()));
+            Assert.True(document.RootElement.GetProperty("metadb_ready").GetBoolean());
             Assert.Equal(0, document.RootElement.GetProperty("ErrorCount").GetInt32());
             Assert.True(document.RootElement.GetProperty("PassCount").GetInt32() > 0);
             Assert.Equal(string.Empty, error.ToString());

--- a/docs/Runtime/ARM64.md
+++ b/docs/Runtime/ARM64.md
@@ -1,0 +1,34 @@
+# ARM64 release artifacts
+
+Extend0 publishes the CLI as self-contained ARM64 artifacts for these runtime identifiers:
+
+- `linux-arm64` on GitHub's native `ubuntu-24.04-arm` runner;
+- `win-arm64` on the native `windows-11-arm` runner;
+- `osx-arm64` on the native Apple Silicon `macos-15` runner.
+
+The NuGet libraries remain architecture-neutral. Only the CLI application is published per runtime identifier.
+
+## Validation contract
+
+Every ARM64 job fails unless all of the following complete on the matching native architecture:
+
+1. the self-contained `extend0` executable runs `doctor --json`;
+2. the JSON version matches the project package version and reports `metadb_ready: true`;
+3. the public `MetaDB.CreateManager()` API creates a mapped table;
+4. a fresh manager reopens the table after the first manager closes it;
+5. the mapped file and its persisted specification can be cleaned up.
+
+Final archives include an SPDX JSON SBOM. Each archive has a sibling SHA-256 checksum and GitHub build-provenance and SBOM attestations. Workflow artifacts are named with the package version and RID and are immutable within their workflow run. A `v<package-version>` tag additionally publishes the same files as GitHub Release assets.
+
+## Verification
+
+After downloading an archive and its checksum:
+
+```bash
+sha256sum --check extend0-cli-<version>-<rid>.<archive>.sha256
+gh attestation verify extend0-cli-<version>-<rid>.<archive> -R Papishushi/Extend0
+```
+
+Use `Get-FileHash -Algorithm SHA256` on Windows. Extract Unix archives with a tool that preserves executable permissions.
+
+The Windows ARM runner is currently a GitHub public-preview image. Its workflow job is required: a generated `win-arm64` archive cannot pass the release gate without executing on that runner.

--- a/eng/Extend0.ReleaseSmoke/Extend0.ReleaseSmoke.csproj
+++ b/eng/Extend0.ReleaseSmoke/Extend0.ReleaseSmoke.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../Extend0/Extend0.csproj" />
+  </ItemGroup>
+</Project>

--- a/eng/Extend0.ReleaseSmoke/Program.cs
+++ b/eng/Extend0.ReleaseSmoke/Program.cs
@@ -1,0 +1,82 @@
+using Extend0.Metadata;
+using Extend0.Metadata.Schema;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+var expectedVersion = args.Length == 1
+    ? args[0]
+    : throw new ArgumentException("Expected exactly one package-version argument.");
+var productVersion = typeof(MetaDB).Assembly
+    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+    ?.InformationalVersion
+    .Split('+', 2)[0] ?? "unknown";
+var tempRoot = Path.Combine(Path.GetTempPath(), "Extend0.ReleaseSmoke", Guid.NewGuid().ToString("N"));
+var mapPath = Path.Combine(tempRoot, "arm64-smoke.meta");
+var specPath = mapPath + ".tablespec.json";
+
+try
+{
+    if (!string.Equals(productVersion, expectedVersion, StringComparison.Ordinal))
+        throw new InvalidOperationException($"Core version '{productVersion}' does not match expected version '{expectedVersion}'.");
+    if (RuntimeInformation.OSArchitecture != Architecture.Arm64)
+        throw new PlatformNotSupportedException($"Expected ARM64, observed {RuntimeInformation.OSArchitecture}.");
+
+    Directory.CreateDirectory(tempRoot);
+    var spec = new TableSpec(
+        "Arm64ReleaseSmoke",
+        mapPath,
+        [TableSpec.Helpers.Column<int>("Value", capacity: 4, keyBytes: 0)]);
+    spec.SaveToFile(specPath);
+
+    using (var manager = MetaDB.CreateManager())
+    {
+        var id = manager.RegisterTable(spec, createNow: true);
+        manager.FillColumn<int>(id, column: 0, rows: 4, static row => checked((int)row + 1));
+        if (!manager.CloseStrict(id))
+            throw new InvalidOperationException("The created table could not be closed.");
+    }
+
+    using (var restartedManager = MetaDB.CreateManager())
+    {
+        var reopened = restartedManager.Open(mapPath, forceRelocation: true);
+        if (!string.Equals(reopened.Table.Spec.Name, spec.Name, StringComparison.Ordinal))
+            throw new InvalidOperationException("The reopened table did not preserve its specification.");
+        if (!restartedManager.CloseStrict(reopened.Id))
+            throw new InvalidOperationException("The reopened table could not be closed.");
+    }
+
+    File.Delete(mapPath);
+    File.Delete(specPath);
+    if (File.Exists(mapPath) || File.Exists(specPath))
+        throw new IOException("MetaDB smoke files remain after cleanup.");
+
+    Console.WriteLine(JsonSerializer.Serialize(new
+    {
+        version = productVersion,
+        runtime_identifier = RuntimeInformation.RuntimeIdentifier,
+        architecture = RuntimeInformation.OSArchitecture.ToString(),
+        metadb_ready = true,
+        create = true,
+        restart = true,
+        cleanup = true
+    }));
+    return 0;
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine(JsonSerializer.Serialize(new
+    {
+        version = productVersion,
+        runtime_identifier = RuntimeInformation.RuntimeIdentifier,
+        architecture = RuntimeInformation.OSArchitecture.ToString(),
+        metadb_ready = false,
+        error = ex.Message
+    }));
+    return 1;
+}
+finally
+{
+    if (Directory.Exists(tempRoot))
+        Directory.Delete(tempRoot, recursive: true);
+}


### PR DESCRIPTION
## Summary

- publish self-contained, single-file CLI artifacts for `linux-arm64`, `win-arm64`, and `osx-arm64`
- execute every RID on a matching native GitHub-hosted ARM64 runner
- extend `doctor --json` with package version, runtime identifier, architecture, and `metadb_ready`
- add a release smoke executable that creates, closes, reopens, and cleans up a real mapped MetaDB table
- generate SPDX JSON SBOMs, SHA-256 checksums, build-provenance attestations, and SBOM attestations
- publish versioned workflow artifacts, and attach the same immutable assets to matching `v<package-version>` tags
- document supported RIDs, native runner requirements, validation, and verification

## Stacked dependency

This PR targets `agent/fix-portable-metadb-semantics` because native Linux/macOS file lifecycle validation depends on PR #8. After #8 merges, this PR should be retargeted to `main`.

## Validation contract

The workflow fails if:

- a runner is not actually ARM64
- `extend0 doctor --json` does not report the expected version, `Arm64`, zero errors, and `metadb_ready: true`
- MetaDB create/restart/cleanup fails
- any RID does not produce its versioned archive, SPDX SBOM, and checksum
- a tag does not exactly match the coherent package version

## Validation results

- [ARM64 release artifacts](https://github.com/Papishushi/Extend0/actions/runs/29358719530): native Linux, Windows, and macOS ARM64 smoke tests and all three finalized artifact jobs passed
- [NuGet packages](https://github.com/Papishushi/Extend0/actions/runs/29358719338): Linux, Windows, macOS, and package validation passed
- Codacy: 0 new issues

Closes #7