### PR TITLE
Stabilize CLI handshake test and guard Linux file unlocks

### DIFF
--- a/Extend0.Tests/Cli/Extend0CliTests.cs
+++ b/Extend0.Tests/Cli/Extend0CliTests.cs
@@ -1717,19 +1717,24 @@ public sealed class Extend0CliTests
         return root;
     }
 
-    private static Task RunRawNamedPipeHandshakeServerAsync(string pipeName, Func<NamedPipeServerStream, Task> handler) =>
-        Task.Run(async () =>
-        {
-            await using var server = new NamedPipeServerStream(
-                pipeName,
-                PipeDirection.InOut,
-                1,
-                PipeTransmissionMode.Byte,
-                PipeOptions.Asynchronous);
+    private static Task RunRawNamedPipeHandshakeServerAsync(string pipeName, Func<NamedPipeServerStream, Task> handler)
+    {
+        var server = new NamedPipeServerStream(
+            pipeName,
+            PipeDirection.InOut,
+            1,
+            PipeTransmissionMode.Byte,
+            PipeOptions.Asynchronous);
 
-            await server.WaitForConnectionAsync();
-            await handler(server);
+        return Task.Run(async () =>
+        {
+            await using (server)
+            {
+                await server.WaitForConnectionAsync();
+                await handler(server);
+            }
         });
+    }
 
     private static string CreateTempDirectory()
     {

--- a/Extend0/Lifecycle/CrossProcess/CrossProcessFileLease.cs
+++ b/Extend0/Lifecycle/CrossProcess/CrossProcessFileLease.cs
@@ -69,6 +69,8 @@ internal sealed class CrossProcessFileLease : IDisposable
 
         try
         {
+            // Linux uses an explicit byte-range lock; Windows and macOS use FileShare.None.
+            // Disposing the stream below releases the active ownership primitive on every platform.
             if (_usesRegionLock && OperatingSystem.IsLinux())
             {
                 try { stream.Unlock(0, 1); }

--- a/Extend0/Lifecycle/CrossProcess/CrossProcessFileLease.cs
+++ b/Extend0/Lifecycle/CrossProcess/CrossProcessFileLease.cs
@@ -69,7 +69,7 @@ internal sealed class CrossProcessFileLease : IDisposable
 
         try
         {
-            if (_usesRegionLock)
+            if (_usesRegionLock && OperatingSystem.IsLinux())
             {
                 try { stream.Unlock(0, 1); }
                 catch (IOException)

--- a/Extend0/Metadata/Storage/Internal/MetadataStorageLease.cs
+++ b/Extend0/Metadata/Storage/Internal/MetadataStorageLease.cs
@@ -106,7 +106,7 @@ internal sealed class MetadataStorageLease : IDisposable
         {
             try
             {
-                if (_usesRegionLock)
+                if (_usesRegionLock && OperatingSystem.IsLinux())
                     stream.Unlock(0, 1);
             }
             catch (IOException)

--- a/Extend0/Metadata/Storage/Internal/MetadataStorageLease.cs
+++ b/Extend0/Metadata/Storage/Internal/MetadataStorageLease.cs
@@ -106,7 +106,9 @@ internal sealed class MetadataStorageLease : IDisposable
         {
             try
             {
-                if (_usesRegionLock && OperatingSystem.IsLinux())
+                // Linux uses an explicit byte-range lock; Windows and macOS use FileShare.None.
+            // Disposing the stream below releases the active ownership primitive on every platform.
+            if (_usesRegionLock && OperatingSystem.IsLinux())
                     stream.Unlock(0, 1);
             }
             catch (IOException)


### PR DESCRIPTION
## Summary

- creates the raw named-pipe server synchronously before the CLI handshake-failure test starts its client;
- preserves explicit byte-range unlocks on Linux while making the platform guard visible to .NET analyzers;
- removes the two `CA1416` warnings for `FileStream.Unlock` without suppressing diagnostics.

## Root cause

`LifecycleDiagnose_WhenHandshakeFails_ReturnsHandshakeFailure` used a second raw-server helper that still created `NamedPipeServerStream` inside `Task.Run`. On a fast Linux runner, the CLI could connect before the pipe existed, classify the result as `NotAttempted`, and fail before exercising the intentionally invalid greeting.

The lease implementations only enable byte-range locks on Linux, but that fact was stored in an instance field. Platform analysis could not infer the field's origin, so both `Unlock` calls were reported as potentially reachable on macOS.

## Validation

- 563/563 tests pass on Ubuntu, macOS and Windows;
- `LifecycleDiagnose_WhenHandshakeFails_ReturnsHandshakeFailure` now reaches and rejects the invalid greeting;
- no `CA1416` warning appears in any of the three test/build logs;
- NuGet package build and inspection pass;
- native ARM64 smoke, packaging, checksums and SBOM generation pass on Linux, macOS and Windows.
