### PR TITLE
Make delete queue fallback test platform independent

### DIFF
--- a/Extend0.Tests/Metadata/MetaDBManagerBehaviorTests.cs
+++ b/Extend0.Tests/Metadata/MetaDBManagerBehaviorTests.cs
@@ -780,12 +780,13 @@ public sealed class MetaDBManagerBehaviorTests
         try
         {
             var queuePath = Path.Combine(tempRoot, "deletes.log");
-            using var handle = MetaDBManagerHarness.CreateManager(factory: _ => MetadataTableHarness.CreateTable(CreateSupportedSpec("QueueFallback", 1)), deleteQueuePath: queuePath);
+            using var handle = MetaDBManagerHarness.CreateManager(
+                factory: _ => MetadataTableHarness.CreateTable(CreateSupportedSpec("QueueFallback", 1)),
+                deleteQueuePath: queuePath,
+                startDeleteWorker: false);
 
             var disabledPath = Path.Combine(tempRoot, "disabled.map");
             File.WriteAllText(disabledPath, "locked");
-            using var disabledLock = new FileStream(disabledPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
-
             handle.SetDeleteQueuePath(string.Empty);
             handle.EnqueueDelete(disabledPath);
 
@@ -795,8 +796,6 @@ public sealed class MetaDBManagerBehaviorTests
             Directory.CreateDirectory(queueAsDirectory);
             var persistenceFailurePath = Path.Combine(tempRoot, "persist-failure.map");
             File.WriteAllText(persistenceFailurePath, "locked");
-            using var persistenceFailureLock = new FileStream(persistenceFailurePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
-
             handle.SetDeleteQueuePath(queueAsDirectory);
             handle.EnqueueDelete(persistenceFailurePath);
             handle.EnqueueDelete(persistenceFailurePath);


### PR DESCRIPTION
## Summary

- disables the background delete worker in the persistence-fallback unit test;
- removes `FileShare.None` handles that incorrectly modeled an undeletable file on macOS;
- keeps the test focused on the in-memory queue contract when persistence is disabled or fails.

## Root cause

The test enqueued an open file and left the manager's delete worker running. Windows prevents deletion through the exclusive file handle, but POSIX systems may unlink an open file. On macOS the worker therefore deleted the file and correctly removed its path from the pending set before the final assertion.

This was a platform-dependent test setup, not a delete-queue product failure.

## Validation

- 563/563 tests pass on Windows, Ubuntu and macOS;
- the formerly failing delete-queue fallback test passes on both macOS runners;
- NuGet package build and inspection pass;
- native ARM64 smoke, packaging, checksums and SBOM generation pass on Windows, Linux and macOS.
