### PR TITLE
Fix analyzer package framework metadata

### DIFF
--- a/Extend0.BlittableAdapter.Generator/Extend0.BlittableAdapter.Generator.csproj
+++ b/Extend0.BlittableAdapter.Generator/Extend0.BlittableAdapter.Generator.csproj
@@ -14,7 +14,6 @@
 		<Description>Generates blittable object structs (GC Free) from a definition file '.blit.json' .</Description>
 		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 		<SuppressWarnings>RS1035</SuppressWarnings>
-		<WarningsNotAsErrors>NU5128</WarningsNotAsErrors>
 		<IsRoslynAnalyzer>true</IsRoslynAnalyzer>
 		<AssemblyVersion>1.0.9691.690</AssemblyVersion>
 		<FileVersion>1.0.9691.690</FileVersion>
@@ -25,6 +24,7 @@
 		<PackageProjectUrl>https://github.com/Papishushi/Extend0</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/Papishushi/Extend0</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
+		<SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
 		<PackageTags>extend0;metadb;metadata;key-value-store;embedded-database;memory-mapped;mmap;</PackageTags>
 		<NeutralLanguage>en-001</NeutralLanguage>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/Extend0.MetadataEntry.Generator/Extend0.MetadataEntry.Generator.csproj
+++ b/Extend0.MetadataEntry.Generator/Extend0.MetadataEntry.Generator.csproj
@@ -14,7 +14,6 @@
 		<Description>Generates blittable MetadataEntry{Key}x{Value} structs (GC Free).</Description>
 		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 		<SuppressWarnings>RS1035</SuppressWarnings>
-		<WarningsNotAsErrors>NU5128</WarningsNotAsErrors>
 		<IsRoslynAnalyzer>true</IsRoslynAnalyzer>
 		<AssemblyVersion>1.0.9691.690</AssemblyVersion>
 		<FileVersion>1.0.9691.690</FileVersion>


### PR DESCRIPTION
## Summary

- suppresses dependency groups when packing `Extend0.BlittableAdapter.Generator`, matching the existing analyzer-only packaging contract of `Extend0.MetadataEntry.Generator`;
- removes the `WarningsNotAsErrors=NU5128` escape hatch from both generator projects;
- keeps generator assemblies under `analyzers/dotnet/cs` instead of adding misleading `lib/netstandard2.0` assets.

## Root cause

`Extend0.BlittableAdapter.Generator` targets `netstandard2.0` for Roslyn compatibility but is distributed as an analyzer, not a compile-time library reference. Its missing `SuppressDependenciesWhenPacking` property caused NuGet to emit a `netstandard2.0` dependency group while the package correctly contained no matching `lib/` or `ref/` assembly, producing two `NU5128` annotations.

## Validation

- all four NuGet packages build and pass package inspection;
- the pack log contains no `NU5128` or other warning annotations;
- 563/563 tests pass on Windows, Ubuntu and macOS;
- native ARM64 smoke, packaging, checksums and SBOM generation pass on Windows, Linux and macOS.
