### PR TITLE
Use AssemblyVersion as the canonical release version

### DIFF
--- a/.github/workflows/arm64-release.yml
+++ b/.github/workflows/arm64-release.yml
@@ -37,7 +37,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v7.0.0
-      - name: Read and validate package version
+      - name: Read and validate assembly version
         id: version
         shell: bash
         run: |
@@ -48,9 +48,9 @@ jobs:
               "Extend0/Extend0.csproj",
               "Extend0.Cli/Extend0.Cli.csproj",
           ]
-          versions = {ET.parse(project).findtext(".//Version") for project in projects}
+          versions = {ET.parse(project).findtext(".//AssemblyVersion") for project in projects}
           if None in versions or len(versions) != 1:
-              raise SystemExit(f"ARM64 project versions are not aligned: {versions}")
+              raise SystemExit(f"ARM64 assembly versions are not aligned: {versions}")
           print(versions.pop())
           PY
           )"

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
-      - name: Verify coherent package version
+      - name: Verify coherent assembly and package version
         id: version
         shell: bash
         run: |
@@ -81,14 +81,14 @@ jobs:
           ]
           versions = {}
           for project in projects:
-              value = ET.parse(project).findtext(".//Version")
+              value = ET.parse(project).findtext(".//AssemblyVersion")
               if not value:
-                  raise SystemExit(f"{project} has no Version")
+                  raise SystemExit(f"{project} has no AssemblyVersion")
               versions[project] = value
 
           unique = set(versions.values())
           if len(unique) != 1:
-              raise SystemExit(f"package versions are not aligned: {versions}")
+              raise SystemExit(f"assembly versions are not aligned: {versions}")
           print(f"version={unique.pop()}")
           PY
       - name: Build package binaries

--- a/Extend0.BlittableAdapter.Generator/Extend0.BlittableAdapter.Generator.csproj
+++ b/Extend0.BlittableAdapter.Generator/Extend0.BlittableAdapter.Generator.csproj
@@ -16,6 +16,8 @@
 		<SuppressWarnings>RS1035</SuppressWarnings>
 		<IsRoslynAnalyzer>true</IsRoslynAnalyzer>
 		<AssemblyVersion>1.1.9691.41434</AssemblyVersion>
+		<PackageVersion>$(AssemblyVersion)</PackageVersion>
+		<InformationalVersion>$(AssemblyVersion)</InformationalVersion>
 		<FileVersion>1.1.9691.41434</FileVersion>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageIcon>Extend0.png</PackageIcon>
@@ -31,7 +33,6 @@
 		<PackageReleaseNotes>
 			Update dependencies to latest versions. Fix NU5128.
 		</PackageReleaseNotes>
-		<Version>1.0.9535</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Extend0.Cli/Extend0.Cli.csproj
+++ b/Extend0.Cli/Extend0.Cli.csproj
@@ -13,8 +13,9 @@
     <Authors>Papishushi</Authors>
     <Description>Command-line diagnostics and validation surface for Extend0 platform contracts.</Description>
     <AssemblyVersion>1.1.9691.41434</AssemblyVersion>
+    <PackageVersion>$(AssemblyVersion)</PackageVersion>
+    <InformationalVersion>$(AssemblyVersion)</InformationalVersion>
     <FileVersion>1.1.9691.41434</FileVersion>
-    <Version>1.0.9535</Version>
     <PackageIcon>Extend0.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Copyright>MIT License</Copyright>

--- a/Extend0.MetadataEntry.Generator/Extend0.MetadataEntry.Generator.csproj
+++ b/Extend0.MetadataEntry.Generator/Extend0.MetadataEntry.Generator.csproj
@@ -16,6 +16,8 @@
 		<SuppressWarnings>RS1035</SuppressWarnings>
 		<IsRoslynAnalyzer>true</IsRoslynAnalyzer>
 		<AssemblyVersion>1.1.9691.41434</AssemblyVersion>
+		<PackageVersion>$(AssemblyVersion)</PackageVersion>
+		<InformationalVersion>$(AssemblyVersion)</InformationalVersion>
 		<FileVersion>1.1.9691.41434</FileVersion>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageIcon>Extend0.png</PackageIcon>
@@ -31,7 +33,6 @@
 		<PackageReleaseNotes>
 
 		</PackageReleaseNotes>
-		<Version>1.0.9535</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Extend0.Tests/Cli/Extend0CliTests.cs
+++ b/Extend0.Tests/Cli/Extend0CliTests.cs
@@ -691,7 +691,7 @@ public sealed class Extend0CliTests
 
             using var document = JsonDocument.Parse(output.ToString());
             Assert.Equal(0, exitCode);
-            Assert.Equal("1.0.9535", document.RootElement.GetProperty("version").GetString());
+            Assert.Equal(typeof(Extend0.Metadata.MetaDB).Assembly.GetName().Version?.ToString(), document.RootElement.GetProperty("version").GetString());
             Assert.False(string.IsNullOrWhiteSpace(document.RootElement.GetProperty("runtime_identifier").GetString()));
             Assert.False(string.IsNullOrWhiteSpace(document.RootElement.GetProperty("architecture").GetString()));
             Assert.True(document.RootElement.GetProperty("metadb_ready").GetBoolean());

--- a/Extend0/Extend0.csproj
+++ b/Extend0/Extend0.csproj
@@ -5,6 +5,8 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<AssemblyVersion>1.1.9691.41434</AssemblyVersion>
+		<PackageVersion>$(AssemblyVersion)</PackageVersion>
+		<InformationalVersion>$(AssemblyVersion)</InformationalVersion>
 		<FileVersion>1.1.9691.41434</FileVersion>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<AssemblyName>Extend0</AssemblyName>
@@ -22,7 +24,6 @@
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageReleaseNotes>
 		</PackageReleaseNotes>
-		<Version>1.0.9535</Version>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary

- removes the four hard-coded `<Version>1.0.9535</Version>` properties;
- derives `PackageVersion` and `InformationalVersion` from each project's `AssemblyVersion`;
- makes the NuGet and ARM64 workflows read and validate `AssemblyVersion`;
- makes the CLI version test compare `doctor` with the loaded core assembly version.

## Result

`AssemblyVersion` is now the single canonical input. The current coherent version is `1.1.9691.41434`, which drives:

- assembly identity and file metadata;
- all four NuGet package versions;
- `doctor --json` and the native MetaDB release smoke;
- artifact names, checksums, SBOM attestations and release tags.

The derived `PackageVersion` is necessary because deleting `Version` alone would make SDK packing fall back to its default package version instead of the explicit assembly version.

## Validation

- all four packages were generated and inspected as `1.1.9691.41434`;
- no package warnings or errors;
- 563/563 tests pass on Windows, Ubuntu and macOS;
- `doctor` reports the assembly version correctly on all three platforms;
- native Windows, Linux and macOS ARM64 smoke, archives, checksums and SBOMs pass.
