### PR TITLE
Publish NuGet packages to GitHub Packages

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -170,6 +170,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     steps:
       - uses: actions/download-artifact@v7.0.0
         with:
@@ -194,3 +195,15 @@ jobs:
           dotnet nuget push "artifacts/Extend0.BlittableAdapter.Generator.$VERSION.nupkg" --api-key "$NUGET_API_KEY" --source "$source_url" --skip-duplicate
           dotnet nuget push "artifacts/Extend0.$VERSION.nupkg" --api-key "$NUGET_API_KEY" --source "$source_url" --skip-duplicate
           dotnet nuget push "artifacts/Extend0.Cli.$VERSION.nupkg" --api-key "$NUGET_API_KEY" --source "$source_url" --skip-duplicate
+      - name: Publish coherent package set to GitHub Packages
+        shell: bash
+        env:
+          GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          VERSION: ${{ needs.pack.outputs.version }}
+        run: |
+          source_url="https://nuget.pkg.github.com/$OWNER/index.json"
+          dotnet nuget push "artifacts/Extend0.MetadataEntry.Generator.$VERSION.nupkg" --api-key "$GITHUB_PACKAGES_TOKEN" --source "$source_url" --skip-duplicate
+          dotnet nuget push "artifacts/Extend0.BlittableAdapter.Generator.$VERSION.nupkg" --api-key "$GITHUB_PACKAGES_TOKEN" --source "$source_url" --skip-duplicate
+          dotnet nuget push "artifacts/Extend0.$VERSION.nupkg" --api-key "$GITHUB_PACKAGES_TOKEN" --source "$source_url" --skip-duplicate
+          dotnet nuget push "artifacts/Extend0.Cli.$VERSION.nupkg" --api-key "$GITHUB_PACKAGES_TOKEN" --source "$source_url" --skip-duplicate


### PR DESCRIPTION
## Summary

Publish the complete Extend0 NuGet package set to GitHub Packages as well as NuGet.org.

## Root cause

The release workflow only pushed packages to NuGet.org. GitHub Packages therefore remained on an older version even though the canonical NuGet feed was current.

## Changes

- grant the publish job scoped `packages: write` permission
- publish all four generated packages to the repository owner's GitHub Packages NuGet feed
- authenticate with the workflow-scoped `GITHUB_TOKEN`
- keep `--skip-duplicate` so reruns are safe
- preserve the existing NuGet trusted-publishing flow unchanged

## Expected result

When this PR is merged, the workflow change on `main` will run the publish job and push version `1.1.9691.41434` to GitHub Packages. Future versions will be published to both feeds from the same validated artifacts.

## Validation

- verified the workflow still derives the package version from the aligned `AssemblyVersion`
- verified the GitHub Packages step references the same four artifacts as the NuGet.org step
- verified package-write permission is scoped to the publish job